### PR TITLE
Rename Scaffoldmaker class for Python 2 import

### DIFF
--- a/scaffoldmaker/scaffolds.py
+++ b/scaffoldmaker/scaffolds.py
@@ -24,7 +24,7 @@ from scaffoldmaker.meshtypes.meshtype_3d_tube1 import MeshType_3d_tube1
 from scaffoldmaker.meshtypes.meshtype_3d_tubeseptum1 import MeshType_3d_tubeseptum1
 
 
-class Scaffoldmaker(object):
+class Scaffolds(object):
 
     def __init__(self):
         self._allMeshTypes = [


### PR DESCRIPTION
Fixes #14. Note clients need to change too.