### PR TITLE
Serialise bytes string to JSON

### DIFF
--- a/scaffoldmaker/scaffolds.py
+++ b/scaffoldmaker/scaffolds.py
@@ -101,8 +101,10 @@ class Scaffolds_JSONEncoder(json.JSONEncoder):
             dct = obj.toDict()
             dct['_ScaffoldPackage'] = True
             return dct
+        elif isinstance(obj, bytes):
+            return obj.decode("utf-8")
         else:
-            super().default(self, obj)
+            super().default(obj)
 
 
 def Scaffolds_decodeJSON(dct):


### PR DESCRIPTION
Zinc now returns a bytes object when fetching serialisation data from a streamresource memory. Now decoding to utf-8 to allow serialisation to JSON.
Also fixed error when calling super class in encoder.