### PR TITLE
Limit bifurcation trim surface intersections to half curve

### DIFF
--- a/src/scaffoldmaker/utils/bifurcation.py
+++ b/src/scaffoldmaker/utils/bifurcation.py
@@ -1377,7 +1377,8 @@ class TubeBifurcationData:
                 for so in sos:
                     otherTrackSurface = self._tubeData[so].getRawTrackSurface()
                     otherSurfacePosition, curveLocation, isIntersection = \
-                        otherTrackSurface.findNearestPositionOnCurve(cx, cd2, loop=False, sampleEnds=False)
+                        otherTrackSurface.findNearestPositionOnCurve(
+                            cx, cd2, loop=False, sampleEnds=False, sampleHalf=2 if self._segmentsIn[s] else 1)
                     if isIntersection:
                         proportion2 = (curveLocation[0] + curveLocation[1]) / (pointsCountAlong - 1)
                         proportionFromEnd = abs(proportion2 - (1.0 if self._segmentsIn[s] else 0.0))

--- a/src/scaffoldmaker/utils/bifurcation.py
+++ b/src/scaffoldmaker/utils/bifurcation.py
@@ -1799,8 +1799,8 @@ def generateTubeBifurcationTree(networkMesh: NetworkMesh, region, coordinates, n
                 loop = (len(startSegmentNode.getInSegments()) == 1) and \
                        (startSegmentNode.getInSegments()[0] is networkSegment) and \
                        (networkSegment.getNodeVersions()[0] == networkSegment.getNodeVersions()[-1])
-                if (elementsCountAlong == 1) and (startTubeBifurcationData or endTubeBifurcationData):
-                    # at least 2 segments if bifurcating at either end, or loop
+                if (elementsCountAlong == 1) and startTubeBifurcationData and endTubeBifurcationData:
+                    # at least 2 segments if bifurcating at both ends
                     elementsCountAlong = 2
                 elif (elementsCountAlong < 3) and loop:
                     # at least 3 segments around loop; 2 should work, but zinc currently makes incorrect faces

--- a/src/scaffoldmaker/utils/tracksurface.py
+++ b/src/scaffoldmaker/utils/tracksurface.py
@@ -1080,7 +1080,7 @@ class TrackSurface:
         return position
 
     def findNearestPositionOnCurve(self, cx, cd1, loop=False, startCurveLocation=None, curveSamples: int = 4,
-                                   sampleEnds=True, instrument=False):
+                                   sampleEnds=True, sampleHalf=0, instrument=False):
         """
         Find nearest/intersection point on curve to this surface.
         :param cx: Coordinates along curve.
@@ -1090,7 +1090,8 @@ class TrackSurface:
         If not supplied, samples curve element coordinates to get nearest initial curve location.
         :param curveSamples: If startLocation not supplied, sets number of curve xi locations to evaluate when finding
         initial nearest curve location.
-        :param sampleEnds: If not loop: set to False to remove start/end points from search for initial curve location.
+        :param sampleEnds: If not loop: set False to remove start/end points from search for initial curve location.
+        :param sampleHalf: Region of curve to search for initial curve location: 0=all, 1=first half, 2=last half.
         :param instrument: Set to True to print debug messages.
         :return: Nearest TrackSurfacePosition on self, nearest/intersection point on curve (element index, xi),
         isIntersection (True/False).
@@ -1110,6 +1111,10 @@ class TrackSurface:
             sCount = eCount * curveSamples
             sStart = 0 if (loop or sampleEnds) else 1
             sLimit = sCount if (loop or not sampleEnds) else sCount + 1
+            if sampleHalf == 1:
+                sLimit = (sCount + 1) // 2  # first half
+            elif sampleHalf == 2:
+                sStart = (sCount - 1) // 2  # last half
             for s in range(sStart, sLimit):
                 tmpCurveLocation = (s // curveSamples, (s % curveSamples) / curveSamples)
                 if not loop and (s == sCount):


### PR DESCRIPTION
Fix case where two segments are intersecting at both ends, ensuring only the regions near the respective end are sampled for initial nearest curve location when finding curve/track surfaces intersections used for building bifurcation trim surfaces.