### PR TITLE
New cap mesh

### DIFF
--- a/src/scaffoldmaker/scaffolds.py
+++ b/src/scaffoldmaker/scaffolds.py
@@ -41,6 +41,8 @@ from scaffoldmaker.meshtypes.meshtype_3d_lung2 import MeshType_3d_lung2
 from scaffoldmaker.meshtypes.meshtype_3d_musclefusiform1 import MeshType_3d_musclefusiform1
 from scaffoldmaker.meshtypes.meshtype_3d_ostium1 import MeshType_3d_ostium1
 from scaffoldmaker.meshtypes.meshtype_3d_ostium2 import MeshType_3d_ostium2
+from scaffoldmaker.meshtypes.meshtype_3d_renal_capsule1 import MeshType_3d_renal_capsule1
+from scaffoldmaker.meshtypes.meshtype_3d_renal_pelvis1 import MeshType_3d_renal_pelvis1
 from scaffoldmaker.meshtypes.meshtype_3d_smallintestine1 import MeshType_3d_smallintestine1
 from scaffoldmaker.meshtypes.meshtype_3d_solidcylinder1 import MeshType_3d_solidcylinder1
 from scaffoldmaker.meshtypes.meshtype_3d_solidsphere1 import MeshType_3d_solidsphere1
@@ -102,6 +104,8 @@ class Scaffolds(object):
             MeshType_3d_musclefusiform1,
             MeshType_3d_ostium1,
             MeshType_3d_ostium2,
+            MeshType_3d_renal_capsule1,
+            MeshType_3d_renal_pelvis1,
             MeshType_3d_smallintestine1,
             MeshType_3d_solidcylinder1,
             MeshType_3d_solidsphere1,

--- a/src/scaffoldmaker/utils/capmesh.py
+++ b/src/scaffoldmaker/utils/capmesh.py
@@ -734,11 +734,12 @@ class CapMesh:
                 for m in range(self._elementsCountCoreBoxMajor + 1):
                     self._shellCoordinates[idx][1][n3][m][n] = sd1[m]
 
+        elementsCountRim = self._elementsCountThroughShell + self._elementsCountTransition - 1
         for m in range(self._elementsCountCoreBoxMajor + 1):
             for n in range(self._elementsCountCoreBoxMinor + 1):
                 otx = self._shellCoordinates[idx][0][-1][m][n]
                 itx = self._shellCoordinates[idx][0][0][m][n]
-                shellFactor = 1.0 / self._elementsCountThroughShell
+                shellFactor = 1.0 / elementsCountRim
                 sd3 = mult(sub(otx, itx), shellFactor)
                 for n3 in range(nodesCountRim):
                     self._shellCoordinates[idx][3][n3][m][n] = sd3
@@ -902,8 +903,12 @@ class CapMesh:
             for n in range(self._elementsCountCoreBoxMinor + 1):
                 otx = self._tubeBoxCoordinates[0][idx][m][n]
                 itx = self._boxCoordinates[idx][0][m][n]
-                d2 = sub(otx, itx)
-                self._boxCoordinates[idx][2][m][n] = mult(d2, signValue)
+                d2 = mult(sub(otx, itx), signValue)
+                self._boxCoordinates[idx][2][m][n] = d2
+                d1 = self._boxCoordinates[idx][1][m][n]
+                d3 = self._boxCoordinates[idx][3][m][n]
+                self._boxCoordinates[idx][1][m][n] = set_magnitude(d1, magnitude(d2))
+                self._boxCoordinates[idx][3][m][n] = set_magnitude(d3, magnitude(d2))
 
     def _createBoundaryNodeIdsList(self, nodeIds):
         """
@@ -952,10 +957,10 @@ class CapMesh:
         :return: x[], d1[], d2[], and d3[] of box nodes in the cap mesh.
         """
         idx = 0 if isStartCap else -1
-        return (self._boxCoordinates[idx][0][m][n],
+        return [self._boxCoordinates[idx][0][m][n],
                 self._boxCoordinates[idx][1][m][n],
                 self._boxCoordinates[idx][2][m][n],
-                self._boxCoordinates[idx][3][m][n])
+                self._boxCoordinates[idx][3][m][n]]
 
     def _getBoxExtCoordinates(self, m, n, isStartCap=True):
         """
@@ -966,10 +971,10 @@ class CapMesh:
         :return: x[], d1[], d2[], and d3[] of box nodes extended from the tube segment.
         """
         idx = 0 if isStartCap else -1
-        return (self._boxExtCoordinates[idx][0][m][n],
+        return [self._boxExtCoordinates[idx][0][m][n],
                 self._boxExtCoordinates[idx][1][m][n],
                 self._boxExtCoordinates[idx][2][m][n],
-                self._boxExtCoordinates[idx][3][m][n])
+                self._boxExtCoordinates[idx][3][m][n]]
 
     def _getRimExtCoordinates(self, n1, n3, isStartCap=True):
         """
@@ -984,15 +989,15 @@ class CapMesh:
                                if (self._transitionExtCoordinates and self._transitionExtCoordinates[idx]) else 0)
 
         if n3 < transitionNodeCount:
-            return (self._transitionExtCoordinates[idx][0][n3][n1],
+            return [self._transitionExtCoordinates[idx][0][n3][n1],
                     self._transitionExtCoordinates[idx][1][n3][n1],
                     self._transitionExtCoordinates[idx][2][n3][n1],
-                    self._transitionExtCoordinates[idx][3][n3][n1])
+                    self._transitionExtCoordinates[idx][3][n3][n1]]
         sn3 = n3 - transitionNodeCount
-        return (self._shellExtCoordinates[idx][0][sn3][n1],
+        return [self._shellExtCoordinates[idx][0][sn3][n1],
                 self._shellExtCoordinates[idx][1][sn3][n1],
                 self._shellExtCoordinates[idx][2][sn3][n1],
-                self._shellExtCoordinates[idx][3][sn3][n1])
+                self._shellExtCoordinates[idx][3][sn3][n1]]
 
     def _getRimExtCoordinatesAround(self, n3, isStartCap=True):
         """
@@ -1027,10 +1032,10 @@ class CapMesh:
         :return: cap rim coordinates and derivatives for points at n3, m and n.
         """
         idx = 0 if isStartCap else -1
-        return (self._shellCoordinates[idx][0][n3][m][n],
+        return [self._shellCoordinates[idx][0][n3][m][n],
                 self._shellCoordinates[idx][1][n3][m][n],
                 self._shellCoordinates[idx][2][n3][m][n],
-                self._shellCoordinates[idx][3][n3][m][n])
+                self._shellCoordinates[idx][3][n3][m][n]]
 
     def _getTubeBoxCoordinates(self, m, n, isStartCap=True):
         """
@@ -1042,10 +1047,10 @@ class CapMesh:
         :return: Tube box coordinates and derivatives for points at n2, m and n.
         """
         idx = 0 if isStartCap else -1
-        return (self._tubeBoxCoordinates[0][idx][m][n],
+        return [self._tubeBoxCoordinates[0][idx][m][n],
                 self._tubeBoxCoordinates[1][idx][m][n],
                 self._tubeBoxCoordinates[2][idx][m][n],
-                self._tubeBoxCoordinates[3][idx][m][n])
+                self._tubeBoxCoordinates[3][idx][m][n]]
 
     def _getTubeRimCoordinates(self, n1, n2, n3):
         """
@@ -1059,10 +1064,10 @@ class CapMesh:
         transitionNodeCount = (len(self._tubeTransitionCoordinates[0][0])
                                if (self._tubeTransitionCoordinates and self._tubeTransitionCoordinates[0]) else 0)
         if n3 < transitionNodeCount and self._isCore:
-            return (self._tubeTransitionCoordinates[0][n2][n3][n1],
+            return [self._tubeTransitionCoordinates[0][n2][n3][n1],
                     self._tubeTransitionCoordinates[1][n2][n3][n1],
                     self._tubeTransitionCoordinates[2][n2][n3][n1],
-                    self._tubeTransitionCoordinates[3][n2][n3][n1])
+                    self._tubeTransitionCoordinates[3][n2][n3][n1]]
         sn3 = n3 - transitionNodeCount
         return [self._tubeShellCoordinates[0][n2][sn3][n1],
                 self._tubeShellCoordinates[1][n2][sn3][n1],
@@ -1486,6 +1491,9 @@ class CapMesh:
         mesh = generateData.getMesh()
         elementtemplateStd, eftStd = generateData.getStandardElementtemplate()
 
+        nodeLayoutTransition = generateData.getNodeLayoutTransition()
+        nodeLayoutCapTransition = generateData.getNodeLayoutCapTransition()
+
         if isStartCap:
             capNodeIds = self._startCapNodeIds
             self._startCapElementIds = [] if self._startCapElementIds is None else self._startCapElementIds
@@ -1529,7 +1537,6 @@ class CapMesh:
         capElementIds.append(boxElementIds)
 
         # box shield elements (elements joining the box and the shell elements)
-        nodeLayoutCapTransition = generateData.getNodeLayoutCapTransition()
         boxshieldElementIds = []
         for e3 in range(elementsCountCoreBoxMajor):
             boxshieldElementIds.append([])
@@ -1550,8 +1557,7 @@ class CapMesh:
                         nodeParameter = self._getBoxCoordinates(n3, n1, isStartCap)
                         nodeParameters.append(nodeParameter)
                         nodeLayoutCapBoxShield = generateData.getNodeLayoutCapBoxShield(boxLocation, isStartCap)
-                        nodeLayoutCapBoxShieldTriplePoint = generateData.getNodeLayoutCapBoxShieldTriplePoint(tpLocation)
-                        nodeLayoutTransitionTriplePoint = generateData.getNodeLayoutTransitionTriplePoint(tpLocation)
+                        nodeLayoutCapBoxShieldTriplePoint = generateData.getNodeLayoutCapBoxShieldTriplePoint(tpLocation, isStartCap)
                         if nid in boxBoundaryNodeIds[0]:
                             nodeLayouts.append(nodeLayoutCapBoxShield if tpLocation == 0 else nodeLayoutCapBoxShieldTriplePoint)
                         else:
@@ -1564,7 +1570,6 @@ class CapMesh:
                 elementtemplate = mesh.createElementtemplate()
                 elementtemplate.setElementShapeType(Element.SHAPE_TYPE_CUBE)
                 elementtemplate.defineField(coordinates, -1, eft)
-
                 element = mesh.createElement(elementIdentifier, elementtemplate)
                 element.setNodesByIdentifier(eft, nids)
                 if scalefactors:
@@ -1610,12 +1615,8 @@ class CapMesh:
             n1p = (e1 + 1) % self._elementsCountAround
             boxLocation = self._getTriplePointLocation(e1)
             shellLocation = self._getTriplePointLocation(e1, isStartCap)
-            nodeLayoutTransition = generateData.getNodeLayoutTransition()
-            nodeLayoutCapTransition = generateData.getNodeLayoutCapTransition()
             nodeLayoutTransitionTriplePoint = generateData.getNodeLayoutTransitionTriplePoint(boxLocation)
             nodeLayoutCapShellTransitionTriplePoint = generateData.getNodeLayoutCapShellTriplePoint(shellLocation)
-
-            elementIdentifier = generateData.nextElementIdentifier()
             for n3 in [0, 1]:
                 for n1 in [e1, n1p]:
                     nid = boxBoundaryNodeIds[n3][n1] if n3 == 0 else rimBoundaryNodeIds[n3 -1][n1]
@@ -1623,10 +1624,10 @@ class CapMesh:
                     mi, ni = boxBoundaryNodeToCapIndex[n3][n1] if n3 == 0 else rimBoundaryNodeToCapIndex[n3 - 1][n1]
                     location, tpLocation = self._getBoxBoundaryLocation(mi, ni)
                     nodeLayoutCapBoxShield = generateData.getNodeLayoutCapBoxShield(location, isStartCap)
-                    nodeLayoutCapBoxShieldTriplePoint = generateData.getNodeLayoutCapBoxShieldTriplePoint(tpLocation)
+                    nodeLayoutCapBoxShieldTriplePoint = generateData.getNodeLayoutCapBoxShieldTriplePoint(tpLocation, isStartCap)
                     if n3 == 0:
                         nodeParameter = self._getBoxCoordinates(mi, ni, isStartCap)
-                        nodeLayout = nodeLayoutTransitionTriplePoint if n1 in triplePointIndexesList else (
+                        nodeLayout = nodeLayoutCapBoxShieldTriplePoint if n1 in triplePointIndexesList else (
                             nodeLayoutCapBoxShield)
                     else:
                         nodeParameter = self._getRimCoordinatesWithCore(mi, ni, 0, isStartCap)
@@ -1650,15 +1651,14 @@ class CapMesh:
                     for a in [nids, nodeParameters, nodeLayouts]:
                         a[-4], a[-2] = a[-2], a[-4]
                         a[-3], a[-1] = a[-1], a[-3]
-            # print("nids", nids)
             eft, scalefactors = determineCubicHermiteSerendipityEft(mesh, nodeParameters, nodeLayouts)
-            if self._elementsCountTransition == 1:
-                eft, scalefactors = generateData.resolveEftCoreBoundaryScaling(
-                    eft, scalefactors, nodeParameters, nids, coreBoundaryScalingMode)
+            # if self._elementsCountTransition == 1:
+            #     eft, scalefactors = generateData.resolveEftCoreBoundaryScaling(
+            #         eft, scalefactors, nodeParameters, nids, coreBoundaryScalingMode)
             elementtemplate = mesh.createElementtemplate()
             elementtemplate.setElementShapeType(Element.SHAPE_TYPE_CUBE)
             elementtemplate.defineField(coordinates, -1, eft)
-
+            elementIdentifier = generateData.nextElementIdentifier()
             element = mesh.createElement(elementIdentifier, elementtemplate)
             element.setNodesByIdentifier(eft, nids)
             if scalefactors:
@@ -1850,8 +1850,8 @@ class CapMesh:
                                 a[-4], a[-2] = a[-2], a[-4]
                                 a[-3], a[-1] = a[-1], a[-3]
                     eft = generateData.createElementfieldtemplate()
-                    eft, scalefactors = addTricubicHermiteSerendipityEftParameterScaling(
-                        eft, scalefactors, nodeParameters, [5, 6, 7, 8], Node.VALUE_LABEL_D_DS3)
+                    # eft, scalefactors = generateData.resolveEftCoreBoundaryScaling(
+                    #     eft, scalefactors, nodeParameters, nids, coreBoundaryScalingMode)
                     elementtemplateTransition = mesh.createElementtemplate()
                     elementtemplateTransition.setElementShapeType(Element.SHAPE_TYPE_CUBE)
                     elementtemplateTransition.defineField(coordinates, -1, eft)

--- a/src/scaffoldmaker/utils/capmesh.py
+++ b/src/scaffoldmaker/utils/capmesh.py
@@ -1,0 +1,1932 @@
+import math
+
+from cmlibs.maths.vectorops import magnitude, sub, add, set_magnitude, normalize, rotate_vector_around_vector, cross, \
+    angle, mult, div
+from cmlibs.zinc.element import Element
+from cmlibs.zinc.node import Node
+from scaffoldmaker.utils.eft_utils import determineCubicHermiteSerendipityEft, \
+    addTricubicHermiteSerendipityEftParameterScaling
+from scaffoldmaker.utils.eftfactory_tricubichermite import eftfactory_tricubichermite
+from scaffoldmaker.utils.interpolation import smoothCubicHermiteDerivativesLoop, smoothCubicHermiteDerivativesLine, \
+    sampleCubicHermiteCurves, interpolateSampleCubicHermite
+from scaffoldmaker.utils.spheremesh import calculate_arc_length, local_to_global_coordinates, spherical_to_cartesian, \
+    calculate_azimuth
+
+
+class CapMesh:
+    """
+    Cap mesh generator.
+    """
+
+    def __init__(self, elementsCountAround, elementsCountCoreBoxMajor, elementsCountCoreBoxMinor,
+                 elementsCountThroughShell, elementsCountTransition, networkPathParameters, tubeBoxCoordinates,
+                 tubeTransitionCoordinates, tubeShellCoordinates, isCap, isCore):
+        """
+        :param elementsCountAround: Number of elements around this segment.
+        :param elementsCountCoreBoxMajor: Number of elements across core box major axis.
+        :param elementsCountCoreBoxMinor: Number of elements across core box minor axis.
+        :param elementsCountThroughShell: Number of elements between inner and outer tube.
+        :param elementsCountTransition: Number of elements across transition zone between core box elements and
+        rim elements.
+        :param networkPathParameters: List containing path parameters of a tube network.
+        :param tubeBoxCoordinates: List of coordinates and derivatives for nodes that form tube box elements.
+        :param tubeTransitionCoordinates: List of coordinates and derivatives for nodes that form tube transition elements.
+        :param tubeShellCoordinates: List of coordinates and derivatives for nodes that form tube rim elements.
+        :param isCap: List [startCap, endCap] with boolean values. True if the tube segment requires a cap at the
+        start of a segment, or at the end of a segment, respectively. [True, True] if the segment requires cap at both
+        ends.
+        :param isCore: True for tube network with a solid core, False for regular tube network.
+        """
+        self._isCap = isCap
+        self._isCore = isCore
+
+        self._elementsCountAround = elementsCountAround
+        self._elementsCountCoreBoxMajor = elementsCountCoreBoxMajor
+        self._elementsCountCoreBoxMinor = elementsCountCoreBoxMinor
+        self._elementsCountThroughShell = elementsCountThroughShell
+        self._elementsCountTransition = elementsCountTransition
+
+        self._networkPathParameters = networkPathParameters
+        self._tubeBoxCoordinates = tubeBoxCoordinates # tube box coordinates
+        self._tubeTransitionCoordinates = tubeTransitionCoordinates # tube transition coordinates
+        self._tubeShellCoordinates = tubeShellCoordinates # tube rim coordinates
+
+        self._boxExtCoordinates = None
+        # coordinates and derivatives for box nodes extended from the tube segment
+        # list[startCap, endCap][x, d1, d2, d3][nAcrossMajor][nAcrossMinor]
+        self._transitionExtCoordinates = None
+        self._shellExtCoordinates = None
+        # coordinates and derivatives for shell nodes extended from the tube segment
+        # list[startCap, endCap][x, d1, d2, d3][nThroughWall][nAround]
+        self._boxExtNodeIds = None
+        self._rimExtNodeIds = None
+
+        self._boxCoordinates = None
+        # list[startCap, endCap][[x, d1, d2, d3][nAcrossMajor][nAcrossMinor]
+        self._shellCoordinates = None
+        # list[startCap, endCap][x, d1, d2, d3][nThroughWall][apex, rim][nAround] if the tube is without the solid core.
+        # list[startCap, endCap][[x, d1, d2, d3][nThroughWall][nAcrossMajor][nAcrossMinor] if the tube is with the core.
+        self._startCapNodeIds = None
+        # capNodeIds that form the cap at the start of a tube segment.
+        # list[nThroughWall][apex, rim] if the tube is without the core.
+        # list[nThroughWall][nAcrossMajor][nAcrossMinor] if the tube is with the core.
+        self._endCapNodeIds = None
+        # capNodeIds that form the cap at the end of a tube segment.
+        # list structure is identical to startCapNodeIds.
+        self._startCapElementIds = None
+        # elementIds that form the cap at the start of a tube segment.
+        # list[nThroughWall][apex, rim] if the tube is without the core.
+        # list[box, rim]: [box] and [rim] sublists have different structures.
+        # [box][core, transition, shield][nAcrossMajor][nAcrossMinor]
+        # [rim][base, shield][nAround]
+        self._endCapElementIds = None
+        # elementIds that form the cap at the end of a tube segment.
+
+    def _extendTubeEnds(self, isStartCap=True):
+        """
+        Add additional tube sections with smaller element size along the tube at either ends of the tube with smaller
+        D2 derivatives. This function is to minimise the effect of large difference in D2 derivatives between the cap
+        mesh and the tube mesh.
+        :param isStartCap:True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+
+        layoutD1 = self._networkPathParameters[0][1][idx]
+        outerRadius = self._calculateOuterShellRadius(isStartCap)
+        # segmentLength = magnitude(sub(self._networkPathParameters[0][0][0], self._networkPathParameters[0][0][1]))
+        # ext = segmentLength * 0.05
+        ext = outerRadius / 2  ## may need another method to calculate extension
+        unitVector = normalize(layoutD1)
+        signValue = -1 if isStartCap else 1
+
+        coreBoxMajorNodesCount = self._elementsCountCoreBoxMajor + 1
+        coreBoxMinorNodesCount = self._elementsCountCoreBoxMinor + 1
+
+        boxCoordinates, transitionCoordinates, shellCoordinates = [], [], []
+        for nx in range(4):
+            boxCoordinates.append([])
+            transitionCoordinates.append([])
+            shellCoordinates.append([])
+            if self._isCore:
+                for m in range(coreBoxMajorNodesCount):
+                    boxCoordinates[nx].append([])
+                    for n in range(coreBoxMinorNodesCount):
+                        boxCoordinates[nx][m].append([])
+                if self._elementsCountTransition > 1:
+                    for n3 in range(self._elementsCountTransition - 1):
+                        transitionCoordinates[nx].append([])
+            for n3 in range(self._elementsCountThroughShell + 1):
+                shellCoordinates[nx].append([])
+
+        if self._isCore:
+            for m in range(coreBoxMajorNodesCount):
+                xList, d2List = [], []
+                x = self._tubeBoxCoordinates[0][idx][m]
+                for n in range(coreBoxMinorNodesCount):
+                    tx = add(x[n], set_magnitude(unitVector, ext * signValue))
+                    td2 = mult(sub(tx, x[n]), signValue)
+                    xList.append(tx)
+                    d2List.append(td2)
+                boxCoordinates[0][m] = xList
+                boxCoordinates[1][m] = self._tubeBoxCoordinates[1][idx][m]
+                boxCoordinates[2][m] = d2List
+                boxCoordinates[3][m] = self._tubeBoxCoordinates[3][idx][m]
+
+            if self._elementsCountTransition > 1:
+                for n3 in range(self._elementsCountTransition - 1):
+                    xList, d2List = [], []
+                    x = self._tubeTransitionCoordinates[0][idx][n3]
+                    for nx in range(self._elementsCountAround):
+                        tx = add(x[nx], set_magnitude(unitVector, ext * signValue))
+                        td2 = mult(sub(tx, x[nx]), signValue)
+                        xList.append(tx)
+                        d2List.append(td2)
+                    transitionCoordinates[0][n3] = xList
+                    transitionCoordinates[1][n3] = self._tubeTransitionCoordinates[1][idx][n3]
+                    transitionCoordinates[2][n3] = d2List
+                    transitionCoordinates[3][n3] = self._tubeTransitionCoordinates[3][idx][n3]
+
+        for n3 in range(self._elementsCountThroughShell + 1):
+            xList, d2List = [], []
+            x = self._tubeShellCoordinates[0][idx][n3]
+            for nx in range(self._elementsCountAround):
+                tx = add(x[nx], set_magnitude(unitVector, ext * signValue))
+                td2 = mult(sub(tx, x[nx]), signValue)
+                xList.append(tx)
+                d2List.append(td2)
+            shellCoordinates[0][n3] = xList
+            shellCoordinates[1][n3] = self._tubeShellCoordinates[1][idx][n3]
+            shellCoordinates[2][n3] = d2List
+            shellCoordinates[3][n3] = self._tubeShellCoordinates[3][idx][n3]
+
+        if self._isCore:
+            self._boxExtCoordinates = [None, None] if self._boxExtCoordinates is None else self._boxExtCoordinates
+            self._boxExtCoordinates[idx] = boxCoordinates
+            if self._elementsCountTransition > 1:
+                self._transitionExtCoordinates = [None, None] if self._transitionExtCoordinates is None \
+                    else self._transitionExtCoordinates
+                self._transitionExtCoordinates[idx] = transitionCoordinates
+
+        self._shellExtCoordinates = [None, None] if self._shellExtCoordinates is None else self._shellExtCoordinates
+        self._shellExtCoordinates[idx] = shellCoordinates
+
+    def _remapCapCoordinates(self, isStartCap=True):
+        """
+        Remap box and rim coordinates of the cap nodes based on the scale of tube extension.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+
+        layoutD1 = self._networkPathParameters[0][1][idx]
+        outerRadius = self._calculateOuterShellRadius(isStartCap)
+        ext = outerRadius / 2
+        # segmentLength = magnitude(sub(self._networkPathParameters[0][0][0], self._networkPathParameters[0][0][1]))
+        # ext = segmentLength * 0.05
+        unitVector = normalize(layoutD1)
+        signValue = -1 if isStartCap else 1
+
+        coreBoxMajorNodesCount = self._getNodesCountCoreBoxMajor()
+        coreBoxMinorNodesCount = self._getNodesCountCoreBoxMinor()
+        nodesCountRim = self._getNodesCountRim()
+
+        if self._isCore:
+            for m in range(coreBoxMajorNodesCount):
+                xList = []
+                x = self._boxCoordinates[idx][0][m]
+                for n in range(coreBoxMinorNodesCount):
+                    tx = add(x[n], set_magnitude(unitVector, ext * signValue))
+                    xList.append(tx)
+                self._boxCoordinates[idx][0][m] = xList
+            for n3 in range(nodesCountRim):
+                for m in range(coreBoxMajorNodesCount):
+                    xList = []
+                    x = self._shellCoordinates[idx][0][n3][m]
+                    for n in range(coreBoxMinorNodesCount):
+                        tx = add(x[n], set_magnitude(unitVector, ext * signValue))
+                        xList.append(tx)
+                    self._shellCoordinates[idx][0][n3][m] = xList
+
+    def _determineCapCoordinatesWithoutCore(self, isStartCap=True):
+        """
+        Calculates coordinates and derivatives for the cap elements. It first calculates the coordinates for the apex
+        nodes, and then calculates the coordinates for rim nodes on the shell surface.
+        Used when the solid core is inactive.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        self._shellCoordinates = [None, None] if self._shellCoordinates is None else self._shellCoordinates
+
+        idx = 0 if isStartCap else -1
+        signValue = 1 if isStartCap else -1
+        pathParameters = self._networkPathParameters[idx]
+
+        outerRadius = self._calculateOuterShellRadius(isStartCap)
+        shellThickness = self._calculateShellThickness(isStartCap)
+        # segmentLength = magnitude(sub(self._networkPathParameters[0][0][0], self._networkPathParameters[0][0][1]))
+        # ext = segmentLength * -0.05
+        ext = -(outerRadius / 2)  ## may need another method to calculate extension
+        centre = add(pathParameters[0][idx], set_magnitude(pathParameters[1][idx], ext * signValue))
+
+        outerWidth = outerLength = outerRadius
+        innerWidth = innerLength = outerRadius - shellThickness
+
+        elementLengthRatioEquatorApex = 1.0
+        lengthRatio = 1.0
+
+        bOuter = 2.0 / (1.0 + elementLengthRatioEquatorApex / lengthRatio)
+        aOuter = 1.0 - bOuter
+        bInner = 2.0 / (1.0 + elementLengthRatioEquatorApex / lengthRatio)
+        aInner = 1.0 - bInner
+
+        elementsCountUp = 2
+        radiansPerElementAround = 2.0 * math.pi / self._elementsCountAround
+        positionOuterArray = [(0, 0)] * elementsCountUp
+        positionInnerArray = [(0, 0)] * elementsCountUp
+        radiansUpOuterArray = [0] * elementsCountUp
+        radiansUpInnerArray = [0] * elementsCountUp
+        vector2OuterArray = [(0, 0)] * elementsCountUp
+        vector2InnerArray = [(0, 0)] * elementsCountUp
+
+        for n2 in range(2):
+            xi = n2 * 2 / (2 * elementsCountUp)
+            nxiOuter = aOuter * xi * xi + bOuter * xi
+            dnxiOuter = 2.0 * aOuter * xi + bOuter
+            radiansUpOuterArray[n2] = radiansUpOuter = nxiOuter * math.pi * 0.5
+            dRadiansUpOuter = dnxiOuter * math.pi / (2 * elementsCountUp)
+            cosRadiansUpOuter = math.cos(radiansUpOuter)
+            sinRadiansUpOuter = math.sin(radiansUpOuter)
+            positionOuterArray[n2] = [outerWidth * sinRadiansUpOuter, -outerLength * cosRadiansUpOuter]
+            vector2OuterArray[n2] = (outerWidth * cosRadiansUpOuter * dRadiansUpOuter,
+                                     outerLength * sinRadiansUpOuter * dRadiansUpOuter)
+
+            nxiInner = aInner * xi * xi + bInner * xi
+            dnxiInner = 2.0 * aInner * xi + bInner
+            radiansUpInnerArray[n2] = radiansUpInner = nxiInner * math.pi * 0.5
+            dRadiansUpInner = dnxiInner * math.pi / (2 * elementsCountUp)
+            cosRadiansUpInner = math.cos(radiansUpInner)
+            sinRadiansUpInner = math.sin(radiansUpInner)
+            positionInnerArray[n2] = [innerWidth * sinRadiansUpInner, -innerLength * cosRadiansUpInner]
+            vector2InnerArray[n2] = (innerWidth * cosRadiansUpInner * dRadiansUpInner,
+                                     innerLength * sinRadiansUpInner * dRadiansUpInner)
+
+        xList, d1List, d2List, d3List, rList = [], [], [], [], []
+        elementsCountThroughShell = self._elementsCountThroughShell
+        for n3 in range(elementsCountThroughShell + 1):
+            for lst in [xList, d1List, d2List, d3List]:
+                lst.append([])
+            for n2 in range(2):
+                n3_fraction = n3 / elementsCountThroughShell
+                positionOuter = positionOuterArray[n2]
+                positionInner = positionInnerArray[n2]
+                position = [positionOuter[0] * n3_fraction + positionInner[0] * (1.0 - n3_fraction),
+                            positionOuter[1] * n3_fraction + positionInner[1] * (1.0 - n3_fraction)]
+                vector2Outer = vector2OuterArray[n2]
+                vector2Inner = vector2InnerArray[n2]
+                vector2 = [vector2Outer[0] * n3_fraction + vector2Inner[0] * (1.0 - n3_fraction),
+                           vector2Outer[1] * n3_fraction + vector2Inner[1] * (1.0 - n3_fraction)]
+                vector3 = [(positionOuter[0] - positionInner[0]) / elementsCountThroughShell,
+                           (positionOuter[1] - positionInner[1]) / elementsCountThroughShell]
+                # calculate coordinates
+                if n2 == 0:  # apex
+                    x = apex = add(pathParameters[0][idx],
+                                   set_magnitude(pathParameters[1][idx], (position[1] + ext) * signValue ))
+                    d1 = set_magnitude(pathParameters[4][idx], vector2[0] * signValue)
+                    d2 = set_magnitude(pathParameters[2][idx], vector2[0])
+                    d3 = set_magnitude(pathParameters[1][idx], vector3[1] * signValue)
+                    for lst, value in zip([xList, d1List, d2List, d3List], [x, d1, d2, d3]):
+                        lst[-1].append(value)
+                else:
+                    refAxis = normalize(pathParameters[4][idx])
+                    rotateAngle = n2 * (math.pi / 2) / elementsCountUp * signValue
+                    radius = innerLength + (outerLength - innerLength) * n3 / elementsCountThroughShell
+                    rList.append(radius)
+                    tx = rotate_vector_around_vector(normalize(sub(apex, centre)), refAxis, -rotateAngle)
+                    tx = set_magnitude(tx, radius)
+                    for n1 in range(self._elementsCountAround):
+                        radiansAround = n1 * radiansPerElementAround
+                        cosRadiansAround = math.cos(radiansAround)
+                        sinRadiansAround = math.sin(radiansAround)
+
+                        rx = rotate_vector_around_vector(tx, pathParameters[1][idx], radiansAround)
+                        rx = add(rx, centre)
+                        d1 = [0.0, position[0] * -sinRadiansAround * radiansPerElementAround * signValue,
+                              position[0] * cosRadiansAround * radiansPerElementAround * signValue]
+                        d2 = [vector2[1], vector2[0] * cosRadiansAround,
+                              vector2[0] * sinRadiansAround]
+                        d3 = [vector3[1], vector3[0] * cosRadiansAround * signValue,
+                              vector3[0] * sinRadiansAround * signValue]
+                        for lst, value in zip([xList, d1List, d2List, d3List], [rx, d1, d2, d3]):
+                            lst[-1].append(value)
+
+        xCoordinates = [[] for _ in range(4)]
+        for n, value in zip(range(4), [xList, d1List, d2List, d3List]):
+            for n3 in range(self._elementsCountThroughShell + 1):
+                xCoordinates[n].append([])
+                xCoordinates[n][n3] = [value[n3][0], value[n3][1:]]
+        self._shellCoordinates[idx] = xCoordinates
+
+        # transform sphere to spheroid
+        for n3 in range(elementsCountThroughShell + 1):
+            radii = self._getTubeRadii(centre, n3, idx)
+            oRadii = [1.0, rList[n3], rList[n3]]
+            ratio = self._getRatioBetweenTwoRadii(radii, oRadii)
+            self._sphereToSpheroid(n3, ratio, centre, isStartCap)
+        # smooth derivatives
+        for n3 in range(elementsCountThroughShell + 1):
+            xList = self._shellCoordinates[idx][0]
+            d1List = self._shellCoordinates[idx][1]
+            sd1 = smoothCubicHermiteDerivativesLoop(xList[n3][1], d1List[n3][1])
+            d1List[n3][1] = sd1
+            for n1 in range(self._elementsCountAround):
+                radiansAround = n1 * radiansPerElementAround
+                x = xList[n3][1][n1]
+                xStart, xEnd = xList[n3][0], self._shellExtCoordinates[idx][0][n3][n1]
+                nx = [xStart, x, xEnd] if isStartCap else [xEnd, x, xStart]
+                d2List = self._shellCoordinates[idx][2]
+                d2Start = rotate_vector_around_vector(d2List[n3][0], pathParameters[1][idx], radiansAround)
+                d2Start = set_magnitude(d2Start, magnitude(d2List[n3][0]) * signValue)
+                d2End = set_magnitude(self._shellExtCoordinates[idx][2][n3][n1],
+                                      magnitude(self._shellExtCoordinates[idx][1][n3][n1]))
+                d2 = d2List[n3][1][n1]
+                nd = [d2Start, d2, d2End] if isStartCap else [d2End, d2, d2Start]
+                sd2 = smoothCubicHermiteDerivativesLine(nx, nd, fixStartDerivative=True, fixEndDerivative=True)
+                d2List[n3][1][n1] = sd2[1]
+        for n1 in range(self._elementsCountAround):
+            xList = self._shellCoordinates[idx][0]
+            d3List = self._shellCoordinates[idx][3]
+            nx = [xList[n3][1][n1] for n3 in range(elementsCountThroughShell + 1)]
+            nd = [d3List[n3][1][n1] for n3 in range(elementsCountThroughShell + 1)]
+            sd3 = smoothCubicHermiteDerivativesLine(nx, nd)
+            for n3 in range(elementsCountThroughShell + 1):
+                d3List[n3][1][n1] = sd3[n3]
+
+    def _determineCapCoordinatesWithCore(self, isStartCap=True):
+        """
+        Blackbox function for calculating coordinates and derivatives for the cap elements.
+        It first calculates the coordinates for shell nodes, then calculates for box nodes.
+        nodes, and then calculates the coordinates for rim nodes on the shell surface.
+        Used when the solid core is active.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        centre = self._networkPathParameters[0][0][idx]
+
+        self._extendTubeEnds(isStartCap) # extend tube end
+        # shell nodes
+        nodesCountRim = self._getNodesCountRim()
+        for n3 in range(nodesCountRim):
+            ox = self._getRimExtCoordinatesAround(n3, isStartCap)[0]
+            radius = self._calculateRadius(ox)
+            radii = self._getTubeRadii(centre, n3, idx) # radii for spheroid
+            oRadii = [1.0, radius, radius] # original radii used to create the sphere
+            ratio = self._getRatioBetweenTwoRadii(radii, oRadii)
+            # ratio between original radii for the sphere and the new radii for spheroid
+            self._calculateMajorAndMinorNodesCoordinates(n3, centre, ratio, isStartCap)
+            self._calculateShellQuadruplePoints(n3, centre, radius, isStartCap)
+            self._calculateShellRegularNodeCoordinates(n3, centre, isStartCap)
+            self._sphereToSpheroid(n3, ratio, centre, isStartCap)
+        self._determineShellDerivatives(isStartCap)
+        # box nodes
+        self._calculateBoxQuadruplePoints(centre, isStartCap)
+        self._calculateBoxMajorAndMinorNodes(isStartCap)
+        self._determineBoxDerivatives(isStartCap)
+
+        self._remapCapCoordinates(isStartCap)
+        self._extendTubeEnds(isStartCap)
+
+    def _createShellCoordinatesList(self):
+        """
+        Creates an empty list for storing rim coordinates. Only applies when the solid core is active.
+        """
+        self._shellCoordinates = [] if self._shellCoordinates is None else self._shellCoordinates
+        elementsCountRim = self._getElementsCountRim()
+        for s in range(2):
+            self._shellCoordinates.append([] if self._isCap[s] else None)
+            if self._shellCoordinates[s] is not None:
+                for nx in range(4):
+                    self._shellCoordinates[s].append([])
+                    for n3 in range(elementsCountRim):
+                        self._shellCoordinates[s][nx].append([])
+                        self._shellCoordinates[s][nx][n3] = [[] for _ in range(self._elementsCountCoreBoxMajor + 1)]
+                        for m in range(self._elementsCountCoreBoxMajor + 1):
+                            self._shellCoordinates[s][nx][n3][m] = \
+                                [None for _ in range(self._elementsCountCoreBoxMinor + 1)]
+
+    def _calculateOuterShellRadius(self, isStartCap=True):
+        """
+        Calculates the radius of an outer shell. It takes the average of a half-distance between two opposing nodes on
+        the outer shell of a tube segment.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :return: Radius of the cap shell.
+        """
+        idx = 0 if isStartCap else -1
+        ox = self._tubeShellCoordinates[0][idx][-1]
+        radii = []
+        for i in range(self._elementsCountAround // 2):
+            j = i + self._elementsCountAround // 2
+            r = magnitude(sub(ox[i], ox[j])) / 2
+            radii.append(r)
+        return sum(radii) / len(radii)
+
+    def _calculateRadius(self, ox):
+        """
+        Calculates the radius of a shell. It takes the average of a half-distance between two opposing nodes around a
+        tube segment.
+        :param ox: Coordinates of shell nodes around a tube segment.
+        :return: Radius of the cap shell.
+        """
+        radii = []
+        for i in range(self._elementsCountAround // 2):
+            j = i + self._elementsCountAround // 2
+            r = magnitude(sub(ox[i], ox[j])) / 2
+            radii.append(r)
+        return sum(radii) / len(radii)
+
+    def _calculateShellThickness(self, isStartCap=True):
+        """
+        Calculates the thickness of a shell, based on the thickness of a tube segment at either ends.
+        It takes the average of a distance between the outer and the inner node pair around the rim of a tube segment.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :return: Thickness of the cap shell.
+        """
+        idx = 0 if isStartCap else -1
+        ix = self._tubeShellCoordinates[0][idx][0]
+        ox = self._tubeShellCoordinates[0][idx][-1]
+
+        shellThicknesses = []
+        for i in range(self._elementsCountAround):
+            thickness = magnitude(sub(ox[i], ix[i]))
+            shellThicknesses.append(thickness)
+        return sum(shellThicknesses) / len(shellThicknesses)
+
+    def _calculateMajorAndMinorNodesCoordinates(self, n3, centre, ratio, isStartCap=True):
+        """
+        Calculates coordinates and derivatives for major and minor axis nodes on the surface of a cap shell by rotating
+        the major and minor axis nodes on the rim of a tube segment.
+        :param n3: Node index from inner to outer rim.
+        :param centre: Centre coordinates of a tube segment at either ends.
+        :param ratio: List of ratios between original circular radii and new radii if the tube is non-circular.
+        [x-axis, major axis, minor axis]. The values should equal 1.0 if the tube cross-section is circular.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        layoutD2 = self._networkPathParameters[0][2][idx]
+        layoutD3 = self._networkPathParameters[0][4][idx]
+
+        elementsCountAcrossMajor = self._elementsCountCoreBoxMajor + 2
+        elementsCountAcrossMinor = self._elementsCountCoreBoxMinor + 2
+
+        refAxis = normalize(layoutD2)
+        rotateAngle = (math.pi / elementsCountAcrossMinor) if isStartCap else \
+            -(math.pi / elementsCountAcrossMinor)
+        minorAxisNodesCoordinates = [[], []] # [startCap, endCap]
+        n1 = self._elementsCountAround * 3 // 4
+        ix = self._getTubeRimCoordinates(n1, idx, n3)
+        for n in range(1, elementsCountAcrossMinor):
+            for nx in [0, 1]:
+                vi = sub(ix[nx], centre) if nx == 0 else mult(ix[nx], -1)
+                vi = div(vi, ratio[2])
+                vr = rotate_vector_around_vector(vi, refAxis, n * rotateAngle)
+                vr = add(vr, centre) if nx == 0 else vr
+                minorAxisNodesCoordinates[nx].append(vr)
+
+        refAxis = normalize(layoutD3)
+        rotateAngle = (math.pi / elementsCountAcrossMajor) if isStartCap else \
+            -(math.pi / elementsCountAcrossMajor)
+        majorAxisNodesCoordinates = [[], []] # [startCap, endCap]
+        ix = self._getTubeRimCoordinates(0, idx, n3)
+        for m in range(1,elementsCountAcrossMajor):
+            for nx in [0, 1]: # [x, d1]
+                vi = sub(ix[nx], centre) if nx == 0 else ix[nx]
+                vi = div(vi, ratio[1])
+                vr = rotate_vector_around_vector(vi, refAxis, m * rotateAngle)
+                vr = add(vr, centre) if nx == 0 else vr
+                majorAxisNodesCoordinates[nx].append(vr)
+
+        midMajorIndex = elementsCountAcrossMajor // 2 - 1
+        midMinorIndex = elementsCountAcrossMinor // 2 - 1
+        for n in range(elementsCountAcrossMinor - 1):
+            for i in [0, 1]:
+                nx = [0, 1][i]
+                if self._shellCoordinates[idx][nx][n3][midMajorIndex][n] is None:
+                    self._shellCoordinates[idx][nx][n3][midMajorIndex][n] = minorAxisNodesCoordinates[i][n]
+        for m in range(elementsCountAcrossMajor - 1):
+            for i in [0, 1]:
+                nx = [0, 2][i]
+                if self._shellCoordinates[idx][nx][n3][m][midMinorIndex] is None:
+                    self._shellCoordinates[idx][nx][n3][m][midMinorIndex] = majorAxisNodesCoordinates[i][m]
+
+        # derivatives
+        for n in range(elementsCountAcrossMinor - 1):
+            if self._shellCoordinates[idx][2][n3][midMajorIndex][n] is None:
+                self._shellCoordinates[idx][2][n3][midMajorIndex][n] = majorAxisNodesCoordinates[1][midMajorIndex]
+        tx = self._shellCoordinates[idx][0][n3][midMajorIndex]
+        td2 = self._shellCoordinates[idx][2][n3][midMajorIndex]
+        self._shellCoordinates[idx][2][n3][midMajorIndex] = smoothCubicHermiteDerivativesLine(tx, td2)
+
+        for m in range(elementsCountAcrossMajor - 1):
+            if self._shellCoordinates[idx][1][n3][m][midMinorIndex] is None:
+                self._shellCoordinates[idx][1][n3][m][midMinorIndex] = minorAxisNodesCoordinates[1][midMinorIndex]
+        tx = [self._shellCoordinates[idx][0][n3][m][midMinorIndex] for m in range(elementsCountAcrossMajor - 1)]
+        td1 = [self._shellCoordinates[idx][1][n3][m][midMinorIndex] for m in range(elementsCountAcrossMajor - 1)]
+        sd1 = smoothCubicHermiteDerivativesLine(tx, td1)
+        for m in range(elementsCountAcrossMajor - 1):
+            self._shellCoordinates[idx][1][n3][m][midMinorIndex] = sd1[m]
+
+    def _calculateShellQuadruplePoints(self, n3, centre, radius, isStartCap=True):
+        """
+        Calculate coordinates and derivatives of the quadruple point on the surface, where 3 hex elements merge.
+        :param n3: Node index from inner to outer rim.
+        :param centre: Centre coordinates of a tube segment at either ends.
+        :param radius: Shell radius.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+
+        layoutD1 = self._networkPathParameters[0][1][idx]
+        layoutD2 = self._networkPathParameters[0][2][idx]
+        layoutD3 = self._networkPathParameters[0][4][idx]
+
+        axesList = [[mult(layoutD1, -1), layoutD2, mult(layoutD3, -1)],
+                    [layoutD2, mult(layoutD1, -1), layoutD3],
+                    [mult(layoutD2, -1), mult(layoutD1, -1), mult(layoutD3, -1)],
+                    [mult(layoutD1, -1), mult(layoutD2, -1), layoutD3]]
+
+        elementsCountUp = 2
+        elementsCountAcrossMajor = self._elementsCountCoreBoxMajor + 2
+        elementsCountAcrossMinor = self._elementsCountCoreBoxMinor + 2
+        counter = 0
+        signValue = 1 if isStartCap else -1
+        for m in [0, -1]:
+            for n in [0, -1]:
+                if m == n:
+                    elementsCount = [elementsCountUp, elementsCountAcrossMajor // 2, elementsCountAcrossMinor // 2]
+                else:
+                    elementsCount = [elementsCountAcrossMajor // 2, elementsCountUp, elementsCountAcrossMinor // 2]
+
+                n1z, n3z = elementsCount[1], elementsCount[2]
+                n1y, n3y = n1z - 1, n3z - 1
+
+                elementsAroundEllipse12 = elementsCount[0] + elementsCount[1] - 2
+                radiansAroundEllipse12 = math.pi / 2
+                radiansPerElementAroundEllipse12 = radiansAroundEllipse12 / elementsAroundEllipse12
+                elementsAroundEllipse13 = elementsCount[0] + elementsCount[2] - 2
+                radiansAroundEllipse13 = math.pi / 2
+                radiansPerElementAroundEllipse13 = radiansAroundEllipse13 / elementsAroundEllipse13
+
+                theta_2 = n3y * radiansPerElementAroundEllipse13
+                theta_3 = n1y * radiansPerElementAroundEllipse12
+                phi_3 = calculate_azimuth(theta_3, theta_2)
+                ratio = 1
+                local_x = spherical_to_cartesian(radius, theta_3, ratio * phi_3 + (1 - ratio) * math.pi / 2)
+                c = counter if isStartCap else -(counter + 1)
+                axes = [mult(axis, signValue) for axis in axesList[c]]
+                x = local_to_global_coordinates(local_x, axes, centre)
+                self._shellCoordinates[idx][0][n3][m][n] = x
+                counter += 1
+
+    def _calculateShellRegularNodeCoordinates(self, n3, centre, isStartCap=True):
+        """
+        Calculate coordinates and derivatives of all other shell nodes on the cap surface.
+        :param n3: Node index from inner to outer rim.
+        :param centre: Centre coordinates of a tube segment at either ends.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        elementsCountAcrossMajor = self._elementsCountCoreBoxMajor + 2
+        elementsCountAcrossMinor = self._elementsCountCoreBoxMinor + 2
+        midMajorIndex = elementsCountAcrossMajor // 2 - 1
+        midMinorIndex = elementsCountAcrossMinor // 2 - 1
+        for m in range(self._elementsCountCoreBoxMajor + 1):
+            elementsOut = self._elementsCountCoreBoxMinor // 2
+            for n in [0, -1]:
+                x1 = self._shellCoordinates[idx][0][n3][m][n]
+                x2 = self._shellCoordinates[idx][0][n3][m][midMinorIndex]
+                if x1 is None:
+                    continue
+                else:
+                    if n == 0:
+                        nx, nd1 = self._sampleCurvesOnSphere(x1, x2, centre, elementsOut)
+                    else:
+                        nx, nd1 = self._sampleCurvesOnSphere(x2, x1, centre, elementsOut)
+                    nRange = [n + 1, midMinorIndex] if n == 0 else \
+                        [midMinorIndex + 1, self._elementsCountCoreBoxMinor]
+                    for c in range(nRange[0], nRange[1]):
+                        self._shellCoordinates[idx][0][n3][m][c] = nx[c % (len(nx) - 1)]
+                        self._shellCoordinates[idx][1][n3][m][c] = nd1[c % (len(nd1) - 1)]
+                        self._shellCoordinates[idx][2][n3][m][c] = [0, 0, 0]
+
+        for n in range(self._elementsCountCoreBoxMinor + 1):
+            elementsOut = self._elementsCountCoreBoxMajor // 2
+            for m in [0, -1]:
+                x1 = self._shellCoordinates[idx][0][n3][m][n]
+                x2 = self._shellCoordinates[idx][0][n3][midMajorIndex][n]
+                if x1 is None:
+                    continue
+                else:
+                    if m == 0:
+                        nx, nd2 = self._sampleCurvesOnSphere(x1, x2, centre, elementsOut)
+                    else:
+                        nx, nd2 = self._sampleCurvesOnSphere(x2, x1, centre, elementsOut)
+                    mRange = [m + 1, midMajorIndex] if m == 0 else [midMajorIndex + 1,
+                                                                    self._elementsCountCoreBoxMajor]
+                    for c in range(mRange[0], mRange[1]):
+                        self._shellCoordinates[idx][0][n3][c][n] = nx[c % (len(nx) - 1)]
+                        self._shellCoordinates[idx][1][n3][c][n] = [0, 0, 0]
+                        self._shellCoordinates[idx][2][n3][c][n] = nd2[c % (len(nd2) - 1)]
+
+    def _sphereToSpheroid(self, n3, ratio, centre, isStartCap=True):
+        """
+        Transform the sphere to ellipsoid using the radius in each direction.
+        :param n3: Node index from inner to outer rim.
+        :param ratio: List of ratios between original circular radii and new radii if the tube is non-circular.
+        [x-axis, major axis, minor axis]. The values should equal 1.0 if the tube cross-section is circular.
+        :param centre: Centre coordinates of a tube segment at either ends.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+
+        # rotation angles to use in case when the cap is tilted from xyz axes.
+        layoutD2 = normalize(self._networkPathParameters[0][2][idx])
+        layoutD3 = normalize(self._networkPathParameters[0][4][idx])
+        thetaD2 = angle(layoutD2, [0.0, 1.0, 0.0])
+        thetaD3 = angle(layoutD3, [0.0, 0.0, 1.0])
+
+        mCount = self._elementsCountCoreBoxMajor + 1 if self._isCore else 1
+        nCount = self._elementsCountCoreBoxMinor + 1 if self._isCore else self._elementsCountAround
+        for m in range(mCount):
+            mp = m if self._isCore else 1
+            for n in range(nCount):
+                btx = self._shellCoordinates[idx][0][n3][mp][n]
+                btx = sub(btx, centre)
+                btx = rotate_vector_around_vector(btx, layoutD3, thetaD2)
+                btx = rotate_vector_around_vector(btx, layoutD2, thetaD3)
+                btx = [ratio[c] * btx[c] for c in range(3)]
+                btx = rotate_vector_around_vector(btx, layoutD3, -thetaD2)
+                btx = rotate_vector_around_vector(btx, layoutD2, -thetaD3)
+                self._shellCoordinates[idx][0][n3][mp][n] = add(btx, centre)
+
+    def _getRatioBetweenTwoRadii(self, radii, oRadii):
+        """
+        Calculates the ratio between the original radius of a sphere and the new radius of an ellipsoid.
+        :param radii: List of new radius in each direction.
+        :param oRadii: List of original radius in each direction.
+        :return: List of ratio between two radii in x, y, and z-direction.
+        """
+        return [radii[c] / oRadii[c] for c in range(3)]
+
+    def _getTubeRadii(self, centre, n3, idx):
+        """
+        Calculates the radius of a tube segment in major axis and minor axis.
+        :param centre:
+        :param n3: Node index from inner to outer rim.
+        :param idx: 0 if calculating for the start segment, -1 if calculating for the end segment.
+        :return: List of radii in major and minor axes. The radius in x-direction is set to 1.0 by default because the
+        radius in this direction is constant.
+        """
+        n1m, n1n = 0, self._elementsCountAround // 4
+        ixm = self._getTubeRimCoordinates(n1m, idx, n3)[0]
+        ixn = self._getTubeRimCoordinates(n1n, idx, n3)[0]
+        majorRadius, minorRadius = magnitude(sub(ixm, centre)), magnitude(sub(ixn, centre))
+
+        return [1.0, majorRadius, minorRadius]
+
+    def _determineShellDerivatives(self, isStartCap=True):
+        """
+        Compute d1, d2, and d3 derivatives for the shell nodes.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        nodesCountRim = self._getNodesCountRim()
+        for n3 in range(nodesCountRim):
+            for m in [0, -1]:
+                for n in [0, -1]:
+                    # initialise derivatives for quadruple points
+                    mp = m + 1 if m == 0 else m - 1
+                    np = n + 1 if n == 0 else n - 1
+                    d1 = sub(self._shellCoordinates[idx][0][n3][mp][n], self._shellCoordinates[idx][0][n3][m][n])
+                    self._shellCoordinates[idx][1][n3][m][n] = mult(d1, -1) if m == -1 else d1
+                    d2 = sub(self._shellCoordinates[idx][0][n3][m][np], self._shellCoordinates[idx][0][n3][m][n])
+                    self._shellCoordinates[idx][2][n3][m][n] = mult(d2, -1) if n == -1 else d2
+
+        for n3 in range(nodesCountRim):
+            for m in range(self._elementsCountCoreBoxMajor + 1):
+                signValue = 1 if isStartCap else -1
+                tx = self._shellCoordinates[idx][0][n3][m]
+                td2 = self._shellCoordinates[idx][2][n3][m]
+                sd2 = smoothCubicHermiteDerivativesLine(tx, td2)
+                for n in range(self._elementsCountCoreBoxMinor + 1):
+                    self._shellCoordinates[idx][2][n3][m][n] = mult(sd2[n], signValue)
+            for n in range(self._elementsCountCoreBoxMinor + 1):
+                tx = [self._shellCoordinates[idx][0][n3][m][n] for m in range(self._elementsCountCoreBoxMajor + 1)]
+                td1 = [self._shellCoordinates[idx][1][n3][m][n] for m in range(self._elementsCountCoreBoxMajor + 1)]
+                sd1 = smoothCubicHermiteDerivativesLine(tx, td1)
+                for m in range(self._elementsCountCoreBoxMajor + 1):
+                    self._shellCoordinates[idx][1][n3][m][n] = sd1[m]
+
+        for m in range(self._elementsCountCoreBoxMajor + 1):
+            for n in range(self._elementsCountCoreBoxMinor + 1):
+                otx = self._shellCoordinates[idx][0][-1][m][n]
+                itx = self._shellCoordinates[idx][0][0][m][n]
+                shellFactor = 1.0 / self._elementsCountThroughShell
+                sd3 = mult(sub(otx, itx), shellFactor)
+                for n3 in range(nodesCountRim):
+                    self._shellCoordinates[idx][3][n3][m][n] = sd3
+
+    def _calculateBoxQuadruplePoints(self, centre, isStartCap=True):
+        """
+        Calculate coordinates and derivatives of the quadruple point for the box elements, where 3 hex elements merge.
+        :param centre: Centre coordinates of a tube segment at either ends.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        capBoxCoordinates = []
+        for nx in range(4):
+            capBoxCoordinates.append([])
+            capBoxCoordinates[nx] = [[] for _ in range(self._elementsCountCoreBoxMajor + 1)]
+            for m in range(self._elementsCountCoreBoxMajor + 1):
+                capBoxCoordinates[nx][m] = [None for _ in range(self._elementsCountCoreBoxMinor + 1)]
+
+        boxCoordinates = self._tubeBoxCoordinates[0][idx]
+        rimCoordinates = self._tubeTransitionCoordinates[0][idx][0] if self._elementsCountTransition > 1 \
+            else self._tubeShellCoordinates[0][idx][0]
+        capCoordinates = self._shellCoordinates[idx][0][0]
+
+        elementsCountAround = self._elementsCountAround
+        nodesCountAcrossMinorHalf = len(boxCoordinates[0]) // 2
+        triplePointIndexesList = []
+        for n in range(0, elementsCountAround, elementsCountAround // 2):
+            triplePointIndexesList.append((n - nodesCountAcrossMinorHalf) % elementsCountAround)
+            triplePointIndexesList.append(n + nodesCountAcrossMinorHalf)
+        triplePointIndexesList[-2], triplePointIndexesList[-1] = triplePointIndexesList[-1], triplePointIndexesList[-2]
+
+        counter = 0
+        for m in [0, -1]:
+            for n in [0, -1]:
+                tpIndex = triplePointIndexesList[counter]
+                x1 = boxCoordinates[m][n]
+                x2 = rimCoordinates[tpIndex]
+                x3 = capCoordinates[m][n]
+
+                ts = magnitude(sub(x1, x2))
+                ra = sub(x3, centre)
+                radius = magnitude(ra)
+                local_x = mult(ra, (1 - ts / radius))
+                x = add(local_x, centre)
+                capBoxCoordinates[0][m][n] = x
+                capBoxCoordinates[1][m][n] = self._tubeBoxCoordinates[1][idx][m][n]
+                capBoxCoordinates[3][m][n] = self._tubeBoxCoordinates[3][idx][m][n]
+                counter += 1
+
+        if self._boxCoordinates is None:
+            self._boxCoordinates = []
+            self._boxCoordinates = [None] * 2
+        self._boxCoordinates[idx] = capBoxCoordinates
+
+    def _calculateBoxMajorAndMinorNodes(self, isStartCap=True):
+        """
+        Calculate coordinates and derivatives for box nodes along the central major and minor axes.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        midMajorIndex = self._elementsCountCoreBoxMajor // 2
+        midMinorIndex = self._elementsCountCoreBoxMinor // 2
+
+        # box side nodes
+        for m in [0, -1]:
+            nx, nd1, nd3 = [], [], []
+            for n in [0, -1]:
+                nx += [self._boxCoordinates[idx][0][m][n]]
+                nd1 += [self._boxCoordinates[idx][1][m][n]]
+                nd3 += [self._boxCoordinates[idx][3][m][n]]
+            tx, td3, pe, pxi, psf = sampleCubicHermiteCurves(nx, nd3, self._elementsCountCoreBoxMinor, arcLengthDerivatives=True)
+            td1 = interpolateSampleCubicHermite(nd1, [[0.0, 0.0, 0.0]] * 2, pe, pxi, psf)[0]
+            for n in range(1, self._elementsCountCoreBoxMinor):
+                self._boxCoordinates[idx][0][m][n] = tx[n]
+                self._boxCoordinates[idx][1][m][n] = td1[n]
+                self._boxCoordinates[idx][3][m][n] = td3[n]
+
+        for n in [0, -1]:
+            nx, nd1, nd3 = [], [], []
+            for m in [0, -1]:
+                nx += [self._boxCoordinates[idx][0][m][n]]
+                nd1 += [self._boxCoordinates[idx][1][m][n]]
+                nd3 += [self._boxCoordinates[idx][3][m][n]]
+            tx, td1, pe, pxi, psf = sampleCubicHermiteCurves(nx, nd1, self._elementsCountCoreBoxMajor, arcLengthDerivatives=True)
+            td3 = interpolateSampleCubicHermite(nd3, [[0.0, 0.0, 0.0]] * 2, pe, pxi, psf)[0]
+            for m in range(1, self._elementsCountCoreBoxMajor):
+                self._boxCoordinates[idx][0][m][n] = tx[m]
+                self._boxCoordinates[idx][1][m][n] = td1[m]
+                self._boxCoordinates[idx][3][m][n] = td3[m]
+
+        # box major and minor nodes
+        nx, nd1, nd3 = [], [], []
+        for n in [0, -1]:
+            nx += [self._boxCoordinates[idx][0][midMajorIndex][n]]
+            nd1 += [self._boxCoordinates[idx][1][midMajorIndex][n]]
+            nd3 += [self._boxCoordinates[idx][3][midMajorIndex][n]]
+        tx, td3, pe, pxi, psf = sampleCubicHermiteCurves(nx, nd3, self._elementsCountCoreBoxMinor, arcLengthDerivatives=True)
+        td1 = interpolateSampleCubicHermite(nd1, [[0.0, 0.0, 0.0]] * 2, pe, pxi, psf)[0]
+        for n in range(1, self._elementsCountCoreBoxMinor):
+            self._boxCoordinates[idx][0][midMajorIndex][n] = tx[n]
+            self._boxCoordinates[idx][1][midMajorIndex][n] = td1[n]
+            self._boxCoordinates[idx][3][midMajorIndex][n] = td3[n]
+
+        nx, nd1 = [], []
+        for m in [0, -1]:
+            nx += [self._boxCoordinates[idx][0][m][midMinorIndex]]
+            nd1 += [self._boxCoordinates[idx][1][m][midMinorIndex]]
+        tx, td1, pe, pxi, psf = sampleCubicHermiteCurves(nx, nd1, self._elementsCountCoreBoxMajor, arcLengthDerivatives=True)
+        td3 = interpolateSampleCubicHermite(nd3, [[0.0, 0.0, 0.0]] * 2, pe, pxi, psf)[0]
+        for m in range(1, self._elementsCountCoreBoxMajor):
+            self._boxCoordinates[idx][0][m][midMinorIndex] = tx[m]
+            self._boxCoordinates[idx][1][m][midMinorIndex] = td1[m]
+            self._boxCoordinates[idx][3][m][midMinorIndex] = td3[m]
+
+        # remaining nodes
+        for m in range(self._elementsCountCoreBoxMajor):
+            for n in range(self._elementsCountCoreBoxMinor):
+                if self._boxCoordinates[idx][0][m][n] is None:
+                    nx = [self._boxCoordinates[idx][0][0][n],
+                          self._boxCoordinates[idx][0][midMajorIndex][n],
+                          self._boxCoordinates[idx][0][-1][n]]
+                    nd1 = [self._boxCoordinates[idx][1][0][n],
+                          self._boxCoordinates[idx][1][midMajorIndex][n],
+                          self._boxCoordinates[idx][1][-1][n]]
+                    nd3 = [self._boxCoordinates[idx][3][0][n],
+                          self._boxCoordinates[idx][3][midMajorIndex][n],
+                          self._boxCoordinates[idx][3][-1][n]]
+                    tx, td1, pe, pxi, psf = sampleCubicHermiteCurves(nx, nd1, self._elementsCountCoreBoxMajor,
+                                                                     arcLengthDerivatives=True)
+                    td3 = interpolateSampleCubicHermite(nd3, [[0.0, 0.0, 0.0]] * 3, pe, pxi, psf)[0]
+                    for mi in range(1, self._elementsCountCoreBoxMajor):
+                        self._boxCoordinates[idx][0][mi][n] = tx[mi]
+                        self._boxCoordinates[idx][1][mi][n] = td1[mi]
+                        self._boxCoordinates[idx][3][mi][n] = td3[mi]
+
+        # smooth derivatives
+        for m in range(1, self._elementsCountCoreBoxMajor):
+            nx = self._boxCoordinates[idx][0][m]
+            nd3 = self._boxCoordinates[idx][3][m]
+            sd3 = smoothCubicHermiteDerivativesLine(nx, nd3)
+            for n in range(1, self._elementsCountCoreBoxMinor):
+                self._boxCoordinates[idx][3][m][n] = sd3[n]
+        for n in range(self._elementsCountCoreBoxMinor):
+            nx = [self._boxCoordinates[idx][0][m][n] for m in range(self._elementsCountCoreBoxMajor + 1)]
+            nd1 = [self._boxCoordinates[idx][1][m][n] for m in range(self._elementsCountCoreBoxMajor + 1)]
+            sd1 = smoothCubicHermiteDerivativesLine(nx, nd1)
+            for m in range(1, self._elementsCountCoreBoxMajor):
+                self._boxCoordinates[idx][1][m][n] = sd1[m]
+
+    def _determineBoxDerivatives(self, isStartCap=True):
+        """
+        Calculate d2 derivatives of box nodes.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        signValue = 1 if isStartCap else -1
+        for m in range(self._elementsCountCoreBoxMajor + 1):
+            for n in range(self._elementsCountCoreBoxMinor + 1):
+                otx = self._tubeBoxCoordinates[0][idx][m][n]
+                itx = self._boxCoordinates[idx][0][m][n]
+                d2 = sub(otx, itx)
+                self._boxCoordinates[idx][2][m][n] = mult(d2, signValue)
+
+    def _createBoundaryNodeIdsList(self, nodeIds):
+        """
+        Creates a list (in a circular format similar to other rim node id lists) of box node ids that are
+        located at the boundary of the box component.
+        This list is used to easily stitch inner rim nodes with box nodes.
+        :param nodeIds: List of box node ids to be rearranged.
+        :return: A list of box node ids stored in a circular format, and a lookup list that translates indexes used in
+        boxBoundaryNodeIds list to indexes that can be used in boxCoordinates list.
+        """
+        capBoundaryNodeIds, capBoundaryNodeToBoxId = [], []
+        boxElementsCountRow = self._elementsCountCoreBoxMajor + 1
+        boxElementsCountColumn = self._elementsCountCoreBoxMinor + 1
+        for n3 in range(boxElementsCountRow):
+            if n3 == 0 or n3 == boxElementsCountRow - 1:
+                ids = nodeIds[n3] if n3 == 0 else nodeIds[n3][::-1]
+                n1List = list(range(boxElementsCountColumn)) if n3 == 0 else (
+                    list(range(boxElementsCountColumn - 1, -1, -1)))
+                capBoundaryNodeIds += [ids[c] for c in range(boxElementsCountColumn)]
+                for n1 in n1List:
+                    capBoundaryNodeToBoxId.append([n3, n1])
+            else:
+                for n1 in [-1, 0]:
+                    capBoundaryNodeIds.append(nodeIds[n3][n1])
+                    capBoundaryNodeToBoxId.append([n3, n1])
+
+        start = self._elementsCountCoreBoxMajor - 2
+        idx = self._elementsCountCoreBoxMinor + 2
+        for n in range(int(start), -1, -1):
+            capBoundaryNodeIds.append(capBoundaryNodeIds.pop(idx + 2 * n))
+            capBoundaryNodeToBoxId.append(capBoundaryNodeToBoxId.pop(idx + 2 * n))
+
+        nloop = self._elementsCountCoreBoxMinor // 2
+        for _ in range(nloop):
+            capBoundaryNodeIds.insert(len(capBoundaryNodeIds), capBoundaryNodeIds.pop(0))
+            capBoundaryNodeToBoxId.insert(len(capBoundaryNodeToBoxId), capBoundaryNodeToBoxId.pop(0))
+
+        return capBoundaryNodeIds, capBoundaryNodeToBoxId
+
+    def _getBoxCoordinates(self, m, n, isStartCap=True):
+        """
+        :param m: Index along the major axis.
+        :param n: Index along the minor axis.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :return: x[], d1[], d2[], and d3[] of box nodes in the cap mesh.
+        """
+        idx = 0 if isStartCap else -1
+        return (self._boxCoordinates[idx][0][m][n],
+                self._boxCoordinates[idx][1][m][n],
+                self._boxCoordinates[idx][2][m][n],
+                self._boxCoordinates[idx][3][m][n])
+
+    def _getBoxExtCoordinates(self, m, n, isStartCap=True):
+        """
+        :param m: Index along the major axis.
+        :param n: Index along the minor axis.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :return: x[], d1[], d2[], and d3[] of box nodes extended from the tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        return (self._boxExtCoordinates[idx][0][m][n],
+                self._boxExtCoordinates[idx][1][m][n],
+                self._boxExtCoordinates[idx][2][m][n],
+                self._boxExtCoordinates[idx][3][m][n])
+
+    def _getRimExtCoordinates(self, n1, n3, isStartCap=True):
+        """
+        :param n1: Index around rim.
+        :param n3: Index from inner to outer rim.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :return: x[], d1[], d2[], and d3[] of rim nodes extended from the tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        transitionNodeCount = (len(self._transitionExtCoordinates[idx][0])
+                               if (self._transitionExtCoordinates and self._transitionExtCoordinates[idx]) else 0)
+
+        if n3 < transitionNodeCount:
+            return (self._transitionExtCoordinates[idx][0][n3][n1],
+                    self._transitionExtCoordinates[idx][1][n3][n1],
+                    self._transitionExtCoordinates[idx][2][n3][n1],
+                    self._transitionExtCoordinates[idx][3][n3][n1])
+        sn3 = n3 - transitionNodeCount
+        return (self._shellExtCoordinates[idx][0][sn3][n1],
+                self._shellExtCoordinates[idx][1][sn3][n1],
+                self._shellExtCoordinates[idx][2][sn3][n1],
+                self._shellExtCoordinates[idx][3][sn3][n1])
+
+    def _getRimExtCoordinatesAround(self, n3, isStartCap=True):
+        """
+        :param n3: Index from inner to outer rim.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :return: x[], d1[], d2[], and d3[] of rim nodes extended from the tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        transitionNodeCount = (len(self._transitionExtCoordinates[idx][0])
+                               if (self._transitionExtCoordinates and self._transitionExtCoordinates[idx]) else 0)
+
+        if n3 < transitionNodeCount:
+            return (self._transitionExtCoordinates[idx][0][n3],
+                    self._transitionExtCoordinates[idx][1][n3],
+                    self._transitionExtCoordinates[idx][2][n3],
+                    self._transitionExtCoordinates[idx][3][n3])
+        sn3 = n3 - transitionNodeCount
+        return (self._shellExtCoordinates[idx][0][sn3],
+                self._shellExtCoordinates[idx][1][sn3],
+                self._shellExtCoordinates[idx][2][sn3],
+                self._shellExtCoordinates[idx][3][sn3])
+
+    def _getRimCoordinatesWithCore(self, m, n, n3, isStartCap=True):
+        """
+        Get coordinates and derivatives for cap rim. Only applies when core option is active.
+        :param m: Index across major axis.
+        :param n: Index across minor axis.
+        :param n3: Index along the tube.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :return: cap rim coordinates and derivatives for points at n3, m and n.
+        """
+        idx = 0 if isStartCap else -1
+        return (self._shellCoordinates[idx][0][n3][m][n],
+                self._shellCoordinates[idx][1][n3][m][n],
+                self._shellCoordinates[idx][2][n3][m][n],
+                self._shellCoordinates[idx][3][n3][m][n])
+
+    def _getTubeBoxCoordinates(self, m, n, isStartCap=True):
+        """
+        Get coordinates and derivatives for tube box.
+        :param m: Index across major axis.
+        :param n: Index across minor axis.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :return: Tube box coordinates and derivatives for points at n2, m and n.
+        """
+        idx = 0 if isStartCap else -1
+        return (self._tubeBoxCoordinates[0][idx][m][n],
+                self._tubeBoxCoordinates[1][idx][m][n],
+                self._tubeBoxCoordinates[2][idx][m][n],
+                self._tubeBoxCoordinates[3][idx][m][n])
+
+    def _getTubeRimCoordinates(self, n1, n2, n3):
+        """
+        Get rim parameters at a point.
+        :param n1: Node index around.
+        :param n2: Node index along segment.
+        :param n3: Node index from inner to outer rim.
+        :param isCore:
+        :return: Tube rim coordinates and derivatives for points at n1, n2 and n3.
+        """
+        transitionNodeCount = (len(self._tubeTransitionCoordinates[0][0])
+                               if (self._tubeTransitionCoordinates and self._tubeTransitionCoordinates[0]) else 0)
+        if n3 < transitionNodeCount and self._isCore:
+            return (self._tubeTransitionCoordinates[0][n2][n3][n1],
+                    self._tubeTransitionCoordinates[1][n2][n3][n1],
+                    self._tubeTransitionCoordinates[2][n2][n3][n1],
+                    self._tubeTransitionCoordinates[3][n2][n3][n1])
+        sn3 = n3 - transitionNodeCount
+        return [self._tubeShellCoordinates[0][n2][sn3][n1],
+                self._tubeShellCoordinates[1][n2][sn3][n1],
+                self._tubeShellCoordinates[2][n2][sn3][n1],
+                self._tubeShellCoordinates[3][n2][sn3][n1]]
+
+    def _getTriplePointIndexes(self):
+        """
+        Get a node ID at triple points (special four corners) of the solid core.
+        :return: A list of circular (n1) indexes used to identify triple points.
+        """
+        elementsCountAround = self._elementsCountAround
+        nodesCountAcrossMinorHalf = self._getNodesCountCoreBoxMinor() // 2
+        triplePointIndexesList = []
+
+        for n in range(0, elementsCountAround, elementsCountAround // 2):
+            triplePointIndexesList.append(n + nodesCountAcrossMinorHalf)
+            triplePointIndexesList.append((n - nodesCountAcrossMinorHalf) % elementsCountAround)
+
+        return triplePointIndexesList
+
+    def _getTriplePointLocation(self, e1, isStartCap=True):
+        """
+        Determines the location of a specific triple point relative to the solid core box.
+        There are four locations: Top left (location = 1); top right (location = -1); bottom left (location = 2);
+        and bottom right (location = -2). Location is None if not located at any of the four specified locations.
+        :return: Location identifier.
+        """
+        em = self._elementsCountCoreBoxMinor // 2
+        eM = self._elementsCountCoreBoxMajor // 2
+        ec = self._elementsCountAround // 4
+
+        lftColumnElements = list(range(0, ec - eM)) + list(range(3 * ec + eM, self._elementsCountAround))
+        topRowElements = list(range(ec - eM, ec + eM))
+        rhtColumnElements = list((range(2 * ec - em, 2 * ec + em)))
+        btmRowElements = list(range(3 * ec - eM, 3 * ec + eM))
+
+        ni = len(lftColumnElements) // 2
+        if e1 == topRowElements[0] or e1 == lftColumnElements[ni - 1]:
+            location = 1  # "TopLeft"
+        elif e1 == topRowElements[-1] or e1 == rhtColumnElements[0]:
+            location = -1  # "TopRight"
+        elif e1 == btmRowElements[-1] or e1 == lftColumnElements[ni]:
+            location = 2  # "BottomLeft"
+        elif e1 == btmRowElements[0] or e1 == rhtColumnElements[-1]:
+            location = -2  # "BottomRight"
+        else:
+            location = 0
+
+        if not isStartCap and location != 0:
+            location = location + 1 if location > 0 else location - 1
+            if abs(location) > 2:
+                location = location - 2 if location > 0 else location + 2
+
+        return location
+
+    def _getBoxBoundaryLocation(self, m, n):
+        """
+        Determines: 1. Where the node is located on the box boundary. There are four side locations: Top, bottom, left,
+        and right; and 2. the location of a triple point relative to the solid core box. There are four locations:
+        Top left, top right, bottom left, and bottom right.
+        Location is 0 if not located at any of the four specified locations.
+        :return: Side location identifier and triple point location identifier.
+        """
+        mEnd = self._getNodesCountCoreBoxMajor() - 1
+        nEnd = self._getNodesCountCoreBoxMinor() - 1
+
+        m = m + self._getNodesCountCoreBoxMajor() if m < 0 else m
+        n = n + self._getNodesCountCoreBoxMinor() if n < 0 else n
+
+        if n == nEnd and 0 < m < mEnd:
+            location = 1  # "Top"
+        elif n == 0 and 0 < m < mEnd:
+            location = -1  # "Bottom"
+        elif m == 0 and 0 < n < nEnd:
+            location = 2  # "Left"
+        elif m == mEnd and 0 < n < nEnd:
+            location = -2  # "Right"
+        else:
+            location = 0
+
+        tpLocation = 0
+        if location == 0:
+            if m == 0 and n == nEnd:
+                tpLocation = 1 # Top Left
+            elif m == mEnd and n == nEnd:
+                tpLocation = -1 # Top Right
+            elif m == 0 and n == 0:
+                tpLocation = 2 # Bottom Left
+            elif m == mEnd and n == 0:
+                tpLocation = -2 # Bottom Right
+
+        return location, tpLocation
+
+    def _getNodesCountCoreBoxMajor(self):
+        idx = -1 if self._boxCoordinates[0] is None else 0
+        return len(self._boxCoordinates[idx][0])
+
+    def _getNodesCountCoreBoxMinor(self):
+        idx = -1 if self._boxCoordinates[0] is None else 0
+        return len(self._boxCoordinates[idx][0][0])
+
+    def _getNodesCountRim(self):
+        nodesCountRim = self._elementsCountThroughShell + self._elementsCountTransition
+        return nodesCountRim
+
+    def _getElementsCountRim(self):
+        elementsCountRim = max(1, self._elementsCountThroughShell)
+        if self._isCore:
+            elementsCountRim += self._elementsCountTransition
+        return elementsCountRim
+
+    def _sampleCurvesOnSphere(self, x1, x2, origin, elementsOut):
+        """
+        Sample coordinates and d1 derivatives of
+        :param x1, x2: Coordinates of points 1 and 2 on the spherical surface of cap mesh.
+        :param origin: Centre point coordinates.
+        :param elementsOut: The number of elements required between points 1 and 2.
+        :return: Lists of sampled x and d1 between points 1 and 2.
+        """
+        r1, r2 = sub(x1, origin), sub(x2, origin)
+        deltax = sub(r2, r1)
+        normal = cross(r1, deltax)
+        theta = angle(r1, r2)
+        anglePerElement = theta / elementsOut
+        arcLengthPerElement = calculate_arc_length(x1, x2, origin) / elementsOut
+
+        nx, nd1 = [], []
+        for n1 in range(elementsOut + 1):
+            radiansAcross = n1 * anglePerElement
+            r = rotate_vector_around_vector(r1, normal, radiansAcross)
+            x = add(r, origin)
+            d1 = set_magnitude(cross(normal, r), arcLengthPerElement)
+            nx.append(x)
+            nd1.append(d1)
+
+        return nx, nd1
+
+    def _generateNodesWithoutCore(self, generateData, isStartCap=True):
+        """
+        Blackbox function for generating cap nodes. Used only when the tube segment does not have a core.
+        :param generateData: TubeNetworkMeshGenerateData class object.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        coordinates = generateData.getCoordinates()
+        fieldcache = generateData.getFieldcache()
+        nodes = generateData.getNodes()
+        nodetemplate = generateData.getNodetemplate()
+
+        nodesCountShell = len(self._tubeShellCoordinates[0][0])
+        capNodeIds = []
+        idx = 0 if isStartCap else -1
+        for n2 in range(2):
+            capNodeIds.append([])
+            for n3 in range(nodesCountShell):
+                capNodeIds[n2].append([])
+                if n2 == 0:  # apex
+                    rx = self._shellCoordinates[idx][0][n3][n2]
+                    rd1 = self._shellCoordinates[idx][1][n3][n2]
+                    rd2 = self._shellCoordinates[idx][2][n3][n2]
+                    rd3 = self._shellCoordinates[idx][3][n3][n2]
+
+                    nodeIdentifier = generateData.nextNodeIdentifier()
+                    node = nodes.createNode(nodeIdentifier, nodetemplate)
+                    fieldcache.setNode(node)
+                    for nodeValue, rValue in zip([Node.VALUE_LABEL_VALUE, Node.VALUE_LABEL_D_DS1,
+                                                  Node.VALUE_LABEL_D_DS2, Node.VALUE_LABEL_D_DS3],
+                                                 [rx, rd1, rd2, rd3]):
+                        coordinates.setNodeParameters(fieldcache, -1, nodeValue, 1, rValue)
+                    capNodeIds[n2][n3].append(nodeIdentifier)
+                else:
+                    for n1 in range(self._elementsCountAround):
+                        rx = self._shellCoordinates[idx][0][n3][n2][n1]
+                        rd1 = self._shellCoordinates[idx][1][n3][n2][n1]
+                        rd2 = self._shellCoordinates[idx][2][n3][n2][n1]
+                        rd3 = self._shellCoordinates[idx][3][n3][n2][n1]
+
+                        nodeIdentifier = generateData.nextNodeIdentifier()
+                        node = nodes.createNode(nodeIdentifier, nodetemplate)
+                        fieldcache.setNode(node)
+                        for nodeValue, rValue in zip([Node.VALUE_LABEL_VALUE, Node.VALUE_LABEL_D_DS1,
+                                                      Node.VALUE_LABEL_D_DS2, Node.VALUE_LABEL_D_DS3],
+                                                     [rx, rd1, rd2, rd3]):
+                            coordinates.setNodeParameters(fieldcache, -1, nodeValue, 1, rValue)
+                        capNodeIds[n2][n3].append(nodeIdentifier)
+
+        if isStartCap:
+            self._startCapNodeIds = capNodeIds
+        else:
+            self._endCapNodeIds = capNodeIds
+
+    def _generateNodesWithCore(self, generateData, isStartCap):
+        """
+        Blackbox function for generating cap nodes. Used only when the tube segment has a core.
+        :param generateData: TubeNetworkMeshGenerateData class object.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        coordinates = generateData.getCoordinates()
+        fieldcache = generateData.getFieldcache()
+        nodes = generateData.getNodes()
+        nodetemplate = generateData.getNodetemplate()
+
+        nodesCountCoreBoxMajor = self._getNodesCountCoreBoxMajor()
+        nodesCountCoreBoxMinor = self._getNodesCountCoreBoxMinor()
+        nloop = self._getNodesCountRim() + 1
+        capNodeIds = []
+        idx = 0 if isStartCap else -1
+        for n3 in range(nloop):
+            if n3 == 0:
+                capNodeIds.append([])
+                for m in range(nodesCountCoreBoxMajor):
+                    capNodeIds[n3].append([])
+                    for n in range(nodesCountCoreBoxMinor):
+                        rx = self._boxCoordinates[idx][0][m][n]
+                        rd1 = self._boxCoordinates[idx][1][m][n]
+                        rd2 = self._boxCoordinates[idx][2][m][n]
+                        rd3 = self._boxCoordinates[idx][3][m][n]
+                        nodeIdentifier = generateData.nextNodeIdentifier()
+                        node = nodes.createNode(nodeIdentifier, nodetemplate)
+                        fieldcache.setNode(node)
+                        for nodeValue, rValue in zip([Node.VALUE_LABEL_VALUE, Node.VALUE_LABEL_D_DS1,
+                                                      Node.VALUE_LABEL_D_DS2, Node.VALUE_LABEL_D_DS3], [rx, rd1, rd2, rd3]):
+                            coordinates.setNodeParameters(fieldcache, -1, nodeValue, 1, rValue)
+                        capNodeIds[n3][m].append(nodeIdentifier)
+            else:
+                capNodeIds.append([])
+                for m in range(nodesCountCoreBoxMajor):
+                    n3p = n3 - 1
+                    capNodeIds[n3].append([])
+                    for n in range(nodesCountCoreBoxMinor):
+                        rx = self._shellCoordinates[idx][0][n3p][m][n]
+                        rd1 = self._shellCoordinates[idx][1][n3p][m][n]
+                        rd2 = self._shellCoordinates[idx][2][n3p][m][n]
+                        rd3 = self._shellCoordinates[idx][3][n3p][m][n]
+
+                        nodeIdentifier = generateData.nextNodeIdentifier()
+                        node = nodes.createNode(nodeIdentifier, nodetemplate)
+                        fieldcache.setNode(node)
+                        for nodeValue, rValue in zip([Node.VALUE_LABEL_VALUE, Node.VALUE_LABEL_D_DS1,
+                                                      Node.VALUE_LABEL_D_DS2, Node.VALUE_LABEL_D_DS3],
+                                                     [rx, rd1, rd2, rd3]):
+                            coordinates.setNodeParameters(fieldcache, -1, nodeValue, 1, rValue)
+                        capNodeIds[n3][m].append(nodeIdentifier)
+
+        if isStartCap:
+            self._startCapNodeIds = capNodeIds
+        else:
+            self._endCapNodeIds = capNodeIds
+
+    def _generateExtendedTubeNodes(self, generateData, isStartCap=True):
+        """
+        Blackbox function for generating tube nodes extended from the original tube segment.
+        :param generateData: TubeNetworkMeshGenerateData class object.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        coordinates = generateData.getCoordinates()
+        fieldcache = generateData.getFieldcache()
+        nodes = generateData.getNodes()
+        nodetemplate = generateData.getNodetemplate()
+
+        # create core box nodes
+        self._boxExtNodeIds = [None, None] if self._boxExtNodeIds is None else self._boxExtNodeIds
+        if self._isCore:
+            self._boxExtNodeIds[idx] = []
+            nodesCountCoreBoxMajor = self._getNodesCountCoreBoxMajor()
+            nodesCountAcrossMinor = self._getNodesCountCoreBoxMinor()
+            for n3 in range(nodesCountCoreBoxMajor):
+                self._boxExtNodeIds[idx].append([])
+                rx = self._boxExtCoordinates[idx][0][n3]
+                rd1 = self._boxExtCoordinates[idx][1][n3]
+                rd2 = self._boxExtCoordinates[idx][2][n3]
+                rd3 = self._boxExtCoordinates[idx][3][n3]
+                for n1 in range(nodesCountAcrossMinor):
+                    nodeIdentifier = generateData.nextNodeIdentifier()
+                    node = nodes.createNode(nodeIdentifier, nodetemplate)
+                    fieldcache.setNode(node)
+                    for nodeValue, rValue in zip([Node.VALUE_LABEL_VALUE, Node.VALUE_LABEL_D_DS1,
+                                                  Node.VALUE_LABEL_D_DS2, Node.VALUE_LABEL_D_DS3],
+                                                 [rx[n1], rd1[n1], rd2[n1], rd3[n1]]):
+                        coordinates.setNodeParameters(fieldcache, -1, nodeValue, 1, rValue)
+                    self._boxExtNodeIds[idx][n3].append(nodeIdentifier)
+
+        # create rim nodes and transition nodes (if there are more than 1 layer of transition)
+        nodesCountRim = self._getNodesCountRim()
+        elementsCountTransition = self._elementsCountTransition
+        self._rimExtNodeIds = [None, None] if self._rimExtNodeIds is None else self._rimExtNodeIds
+        self._rimExtNodeIds[idx] = []
+        for n3 in range(nodesCountRim):
+            n3p = n3 - (elementsCountTransition - 1) if self._isCore else n3
+            if self._isCore and elementsCountTransition > 1 and n3 < (elementsCountTransition - 1):
+                # transition coordinates
+                rx = self._transitionExtCoordinates[idx][0][n3]
+                rd1 = self._transitionExtCoordinates[idx][1][n3]
+                rd2 = self._transitionExtCoordinates[idx][2][n3]
+                rd3 = self._transitionExtCoordinates[idx][3][n3]
+            else:
+                # rim coordinates
+                rx = self._shellExtCoordinates[idx][0][n3p]
+                rd1 = self._shellExtCoordinates[idx][1][n3p]
+                rd2 = self._shellExtCoordinates[idx][2][n3p]
+                rd3 = self._shellExtCoordinates[idx][3][n3p]
+            ringNodeIds = []
+            for n1 in range(self._elementsCountAround):
+                nodeIdentifier = generateData.nextNodeIdentifier()
+                node = nodes.createNode(nodeIdentifier, nodetemplate)
+                fieldcache.setNode(node)
+                coordinates.setNodeParameters(fieldcache, -1, Node.VALUE_LABEL_VALUE, 1, rx[n1])
+                coordinates.setNodeParameters(fieldcache, -1, Node.VALUE_LABEL_D_DS1, 1, rd1[n1])
+                coordinates.setNodeParameters(fieldcache, -1, Node.VALUE_LABEL_D_DS2, 1, rd2[n1])
+                coordinates.setNodeParameters(fieldcache, -1, Node.VALUE_LABEL_D_DS3, 1, rd3[n1])
+                ringNodeIds.append(nodeIdentifier)
+            self._rimExtNodeIds[idx].append(ringNodeIds)
+
+    def _generateElementsWithoutCore(self, generateData, elementsCountRim, tubeRimNodeIds, annotationMeshGroups,
+                                     isStartCap=True):
+        """
+        Blackbox function for generating cap elements. Used only when the tube segment does not have a core.
+        :param generateData: TubeNetworkMeshGenerateData class object.
+        :param elementsCountRim: Number of elements through the rim.
+        :param tubeRimNodeIds: List of tube rim nodes.
+        :param annotationMeshGroups: List of all annotated mesh groups.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        coordinates = generateData.getCoordinates()
+        mesh = generateData.getMesh()
+        elementtemplateStd, eftStd = generateData.getStandardElementtemplate()
+        eftfactory = eftfactory_tricubichermite(mesh, False)
+
+        if isStartCap:
+            capNodeIds = self._startCapNodeIds
+            self._startCapElementIds = [] if self._startCapElementIds is None else self._startCapElementIds
+        else:
+            capNodeIds = self._endCapNodeIds
+            self._endCapElementIds = [] if self._endCapElementIds is None else self._endCapElementIds
+        capElementIds = []
+        for e3 in range(elementsCountRim):
+            capElementIds.append([])
+            for e2 in range(2):
+                capElementIds[e3].append([])
+                if e2 == 0:
+                    for e1 in range(self._elementsCountAround):
+                        e1p = (e1 + 1) % self._elementsCountAround
+                        nids = []
+                        for n3 in [e3, e3 + 1]:
+                            if isStartCap:
+                                nids += [capNodeIds[0][n3][0], capNodeIds[1][n3][e1], capNodeIds[1][n3][e1p]]
+                            else:
+                                nids += [capNodeIds[1][n3][e1], capNodeIds[1][n3][e1p], capNodeIds[0][n3][0]]
+                        elementIdentifier = generateData.nextElementIdentifier()
+                        va, vb = e1, (e1 + 1) % self._elementsCountAround
+                        if isStartCap:
+                            eftCap = eftfactory.createEftShellPoleBottom(va * 100, vb * 100)
+                        else:
+                            eftCap = eftfactory.createEftShellPoleTop(va * 100, vb * 100)
+                        elementtemplateCap = mesh.createElementtemplate()
+                        elementtemplateCap.setElementShapeType(Element.SHAPE_TYPE_CUBE)
+                        elementtemplateCap.defineField(coordinates, -1, eftCap)
+                        element = mesh.createElement(elementIdentifier, elementtemplateCap)
+                        element.setNodesByIdentifier(eftCap, nids)
+
+                        # set general linear map coefficients
+                        radiansPerElementAround = math.pi * 2.0 / self._elementsCountAround
+                        radiansAround = e1 * radiansPerElementAround if isStartCap else math.pi + e1 * radiansPerElementAround
+                        radiansAroundNext = ((e1 + 1) % radiansPerElementAround) * radiansPerElementAround if isStartCap \
+                            else math.pi + ((e1 + 1) % self._elementsCountAround) * radiansPerElementAround
+                        scalefactors = [
+                            1.0,
+                            math.sin(radiansAround), math.cos(radiansAround), radiansPerElementAround,
+                            math.sin(radiansAroundNext), math.cos(radiansAroundNext), radiansPerElementAround,
+                            math.sin(radiansAround), math.cos(radiansAround), radiansPerElementAround,
+                            math.sin(radiansAroundNext), math.cos(radiansAroundNext), radiansPerElementAround
+                        ]
+                        if not isStartCap:
+                            for s in [0, 1, 4, 7, 10]:
+                                scalefactors[s] *= -1
+                        element.setScaleFactors(eftCap, scalefactors)
+                        # for annotationMeshGroup in annotationMeshGroups:
+                        #     annotationMeshGroup.addElement(element)
+                        capElementIds[e3][e2].append(elementIdentifier)
+                else:
+                    idx = 0 if isStartCap else -1
+                    for e1 in range(self._elementsCountAround):
+                        e1p = (e1 + 1) % self._elementsCountAround
+                        nids = []
+                        for n3 in [e3, e3 + 1]:
+                            nids += [capNodeIds[e2][n3][e1], capNodeIds[e2][n3][e1p],
+                                     self._rimExtNodeIds[idx][n3][e1], self._rimExtNodeIds[idx][n3][e1p]]
+                            if not isStartCap:
+                                for a in [nids]:
+                                    a[-4], a[-2] = a[-2], a[-4]
+                                    a[-3], a[-1] = a[-1], a[-3]
+                        elementIdentifier = generateData.nextElementIdentifier()
+                        element = mesh.createElement(elementIdentifier, elementtemplateStd)
+                        element.setNodesByIdentifier(eftStd, nids)
+                        capElementIds[e3][e2].append(elementIdentifier)
+
+        if isStartCap:
+            self._startCapElementIds = capElementIds
+        else:
+            self._endCapElementIds = capElementIds
+
+    def _generateElementsWithCore(self, generateData, coreBoundaryScalingMode, isStartCap=True):
+        """
+        Blackbox function for generating cap elements. Used only when the tube segment has a core.
+        :param generateData: TubeNetworkMeshGenerateData class object.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+        elementsCountAround = self._elementsCountAround
+        elementsCountCoreBoxMinor = self._elementsCountCoreBoxMinor
+        elementsCountCoreBoxMajor = self._elementsCountCoreBoxMajor
+        elementsCountRim = self._getElementsCountRim()
+
+        coordinates = generateData.getCoordinates()
+        mesh = generateData.getMesh()
+        elementtemplateStd, eftStd = generateData.getStandardElementtemplate()
+
+        if isStartCap:
+            capNodeIds = self._startCapNodeIds
+            self._startCapElementIds = [] if self._startCapElementIds is None else self._startCapElementIds
+        else:
+            capNodeIds = self._endCapNodeIds
+            self._endCapElementIds = [] if self._endCapElementIds is None else self._endCapElementIds
+        boxExtNodeIds = self._boxExtNodeIds[idx]
+        rimExtNodeIds = self._rimExtNodeIds[idx]
+        triplePointIndexesList = self._getTriplePointIndexes()
+
+        capElementIds = []
+        boxBoundaryNodeIds, boxBoundaryNodeToCapIndex = [], []
+        rimBoundaryNodeIds, rimBoundaryNodeToCapIndex = [], []
+        for n2 in range(elementsCountRim + 1):
+            if n2 == 0:
+                boxBoundaryNodeIds.append(self._createBoundaryNodeIdsList(capNodeIds[n2])[0])
+                boxBoundaryNodeToCapIndex.append(self._createBoundaryNodeIdsList(capNodeIds[n2])[1])
+            else:
+                rimBoundaryNodeIds.append(self._createBoundaryNodeIdsList(capNodeIds[n2])[0])
+                rimBoundaryNodeToCapIndex.append(self._createBoundaryNodeIdsList(capNodeIds[n2])[1])
+
+        # box & shield
+        # box
+        boxElementIds = []
+        for e3 in range(elementsCountCoreBoxMajor):
+            boxElementIds.append([])
+            e3p = e3 + 1
+            for e1 in range(elementsCountCoreBoxMinor):
+                nids, nodeParameters, nodeLayouts = [], [], []
+                for n1 in [e1, e1 + 1]:
+                    nids += [capNodeIds[0][e3][n1], capNodeIds[0][e3p][n1],
+                             boxExtNodeIds[e3][n1], boxExtNodeIds[e3p][n1]]
+                    if not isStartCap:
+                        for a in [nids]:
+                            a[-4], a[-2] = a[-2], a[-4]
+                            a[-3], a[-1] = a[-1], a[-3]
+                elementIdentifier = generateData.nextElementIdentifier()
+                element = mesh.createElement(elementIdentifier, elementtemplateStd)
+                element.setNodesByIdentifier(eftStd, nids)
+                boxElementIds[e3].append(elementIdentifier)
+        capElementIds.append(boxElementIds)
+
+        # box shield elements (elements joining the box and the shell elements)
+        nodeLayoutCapTransition = generateData.getNodeLayoutCapTransition()
+        boxshieldElementIds = []
+        for e3 in range(elementsCountCoreBoxMajor):
+            boxshieldElementIds.append([])
+            e3p = e3 + 1
+            for e1 in range(elementsCountCoreBoxMinor):
+                nids, nodeParameters, nodeLayouts = [], [], []
+                elementIdentifier = generateData.nextElementIdentifier()
+                for n1 in [e1, e1 + 1]:
+                    for n3 in [e3, e3p]:
+                        nids += [capNodeIds[1][n3][n1]]
+                        nodeParameter = self._getRimCoordinatesWithCore(n3, n1, 0, isStartCap)
+                        nodeParameters.append(nodeParameter)
+                        nodeLayouts.append(nodeLayoutCapTransition)
+                    for n3 in [e3, e3p]:
+                        boxLocation, tpLocation = self._getBoxBoundaryLocation(n3, n1)
+                        nid = capNodeIds[0][n3][n1]
+                        nids += [nid]
+                        nodeParameter = self._getBoxCoordinates(n3, n1, isStartCap)
+                        nodeParameters.append(nodeParameter)
+                        nodeLayoutCapBoxShield = generateData.getNodeLayoutCapBoxShield(boxLocation, isStartCap)
+                        nodeLayoutCapBoxShieldTriplePoint = generateData.getNodeLayoutCapBoxShieldTriplePoint(tpLocation)
+                        nodeLayoutTransitionTriplePoint = generateData.getNodeLayoutTransitionTriplePoint(tpLocation)
+                        if nid in boxBoundaryNodeIds[0]:
+                            nodeLayouts.append(nodeLayoutCapBoxShield if tpLocation == 0 else nodeLayoutCapBoxShieldTriplePoint)
+                        else:
+                            nodeLayouts.append(None)
+                    if not isStartCap:
+                        for a in [nids, nodeParameters, nodeLayouts]:
+                            a[-4], a[-2] = a[-2], a[-4]
+                            a[-3], a[-1] = a[-1], a[-3]
+                eft, scalefactors = determineCubicHermiteSerendipityEft(mesh, nodeParameters, nodeLayouts)
+                elementtemplate = mesh.createElementtemplate()
+                elementtemplate.setElementShapeType(Element.SHAPE_TYPE_CUBE)
+                elementtemplate.defineField(coordinates, -1, eft)
+
+                element = mesh.createElement(elementIdentifier, elementtemplate)
+                element.setNodesByIdentifier(eft, nids)
+                if scalefactors:
+                    element.setScaleFactors(eft, scalefactors)
+                boxshieldElementIds[e3].append(elementIdentifier)
+        capElementIds.append(boxshieldElementIds)
+
+        # shield
+        for e3 in range(elementsCountRim - 1):
+            e3p = e3 + 1
+            shieldElementIds = []
+            for e2 in range(self._elementsCountCoreBoxMajor):
+                e2p = e2 + 1
+                shieldElementIds.append([])
+                for e1 in range(elementsCountCoreBoxMinor):
+                    e1p = e1 + 1
+                    nids = []
+                    for n3 in [e3p, e3p + 1]:
+                        nids += [capNodeIds[n3][e2][e1], capNodeIds[n3][e2p][e1],
+                                 capNodeIds[n3][e2][e1p], capNodeIds[n3][e2p][e1p]]
+                        if not isStartCap:
+                            for a in [nids]:
+                                a[-4], a[-2] = a[-2], a[-4]
+                                a[-3], a[-1] = a[-1], a[-3]
+                    elementIdentifier = generateData.nextElementIdentifier()
+                    element = mesh.createElement(elementIdentifier, elementtemplateStd)
+                    element.setNodesByIdentifier(eftStd, nids)
+                    shieldElementIds[e2].append(elementIdentifier)
+            capElementIds.append(shieldElementIds)
+
+        if isStartCap:
+            self._startCapElementIds.append(capElementIds)
+        else:
+            self._endCapElementIds.append(capElementIds)
+
+        # rim
+        capElementIds = []
+        # box transition
+        ringElementIds = []
+        boxExtBoundaryNodeIds, boxExtBoundaryNodestoBoxIds = self._createBoundaryNodeIdsList(boxExtNodeIds)
+        for e1 in range(elementsCountAround):
+            nids, nodeParameters, nodeLayouts = [], [], []
+            n1p = (e1 + 1) % self._elementsCountAround
+            boxLocation = self._getTriplePointLocation(e1)
+            shellLocation = self._getTriplePointLocation(e1, isStartCap)
+            nodeLayoutTransition = generateData.getNodeLayoutTransition()
+            nodeLayoutCapTransition = generateData.getNodeLayoutCapTransition()
+            nodeLayoutTransitionTriplePoint = generateData.getNodeLayoutTransitionTriplePoint(boxLocation)
+            nodeLayoutCapShellTransitionTriplePoint = generateData.getNodeLayoutCapShellTriplePoint(shellLocation)
+
+            elementIdentifier = generateData.nextElementIdentifier()
+            for n3 in [0, 1]:
+                for n1 in [e1, n1p]:
+                    nid = boxBoundaryNodeIds[n3][n1] if n3 == 0 else rimBoundaryNodeIds[n3 -1][n1]
+                    nids += [nid]
+                    mi, ni = boxBoundaryNodeToCapIndex[n3][n1] if n3 == 0 else rimBoundaryNodeToCapIndex[n3 - 1][n1]
+                    location, tpLocation = self._getBoxBoundaryLocation(mi, ni)
+                    nodeLayoutCapBoxShield = generateData.getNodeLayoutCapBoxShield(location, isStartCap)
+                    nodeLayoutCapBoxShieldTriplePoint = generateData.getNodeLayoutCapBoxShieldTriplePoint(tpLocation)
+                    if n3 == 0:
+                        nodeParameter = self._getBoxCoordinates(mi, ni, isStartCap)
+                        nodeLayout = nodeLayoutTransitionTriplePoint if n1 in triplePointIndexesList else (
+                            nodeLayoutCapBoxShield)
+                    else:
+                        nodeParameter = self._getRimCoordinatesWithCore(mi, ni, 0, isStartCap)
+                        nodeLayout = nodeLayoutCapShellTransitionTriplePoint if n1 in triplePointIndexesList else (
+                            nodeLayoutCapTransition)
+                    nodeParameters.append(nodeParameter)
+                    nodeLayouts.append(nodeLayout)
+                for n1 in [e1, n1p]:
+                    if n3 == 0:
+                        nid = boxExtBoundaryNodeIds[n1]
+                        mi, ni = boxExtBoundaryNodestoBoxIds[n1]
+                        nodeParameter = self._getBoxExtCoordinates(mi, ni, isStartCap)
+                    else:
+                        nid = rimExtNodeIds[0][n1]
+                        nodeParameter = self._getRimExtCoordinates(n1, 0, isStartCap)
+                    nids += [nid]
+                    nodeParameters.append(nodeParameter)
+                    nodeLayouts.append(nodeLayoutTransitionTriplePoint if n1 in triplePointIndexesList and n3 == 0
+                                       else nodeLayoutTransition)
+                if not isStartCap:
+                    for a in [nids, nodeParameters, nodeLayouts]:
+                        a[-4], a[-2] = a[-2], a[-4]
+                        a[-3], a[-1] = a[-1], a[-3]
+            # print("nids", nids)
+            eft, scalefactors = determineCubicHermiteSerendipityEft(mesh, nodeParameters, nodeLayouts)
+            if self._elementsCountTransition == 1:
+                eft, scalefactors = generateData.resolveEftCoreBoundaryScaling(
+                    eft, scalefactors, nodeParameters, nids, coreBoundaryScalingMode)
+            elementtemplate = mesh.createElementtemplate()
+            elementtemplate.setElementShapeType(Element.SHAPE_TYPE_CUBE)
+            elementtemplate.defineField(coordinates, -1, eft)
+
+            element = mesh.createElement(elementIdentifier, elementtemplate)
+            element.setNodesByIdentifier(eft, nids)
+            if scalefactors:
+                element.setScaleFactors(eft, scalefactors)
+            ringElementIds.append(elementIdentifier)
+        capElementIds.append(ringElementIds)
+
+        # shell
+        triplePointIndexesList = self._getTriplePointIndexes()
+        for e3 in range(elementsCountRim - 1):
+            rimElementIds = []
+            for e1 in range(self._elementsCountAround):
+                nids, nodeParameters, nodeLayouts = [], [], []
+                e1p = (e1 + 1) % self._elementsCountAround
+                location = self._getTriplePointLocation(e1, isStartCap)
+                nodeLayoutCapTransition = generateData.getNodeLayoutCapTransition()
+                nodeLayoutCapShellTriplePoint = generateData.getNodeLayoutCapShellTriplePoint(location)
+                for n3 in [e3, e3 + 1]:
+                    for n1 in [e1, e1p]:
+                        nids += [rimBoundaryNodeIds[n3][n1]]
+                        mi, ni = rimBoundaryNodeToCapIndex[n3][n1]
+                        nodeParameter = self._getRimCoordinatesWithCore(mi, ni, n3, isStartCap)
+                        nodeParameters.append(nodeParameter)
+                        nodeLayouts.append(nodeLayoutCapShellTriplePoint if n1 in triplePointIndexesList else
+                                           nodeLayoutCapTransition)
+                    for n1 in [e1, e1p]:
+                        nids += [rimExtNodeIds[n3][n1]]
+                        nodeParameter = self._getRimExtCoordinates(n1, n3, isStartCap)
+                        nodeParameters.append(nodeParameter)
+                        nodeLayouts.append(None)
+                    if not isStartCap:
+                        for a in [nids, nodeParameters, nodeLayouts]:
+                            a[-4], a[-2] = a[-2], a[-4]
+                            a[-3], a[-1] = a[-1], a[-3]
+                elementIdentifier = generateData.nextElementIdentifier()
+                eft, scalefactors = determineCubicHermiteSerendipityEft(mesh, nodeParameters, nodeLayouts)
+                elementtemplate = mesh.createElementtemplate()
+                elementtemplate.setElementShapeType(Element.SHAPE_TYPE_CUBE)
+                elementtemplate.defineField(coordinates, -1, eft)
+                element = mesh.createElement(elementIdentifier, elementtemplate)
+                element.setNodesByIdentifier(eft, nids)
+                if scalefactors:
+                    element.setScaleFactors(eft, scalefactors)
+                rimElementIds.append(elementIdentifier)
+            capElementIds.append(rimElementIds)
+
+        if isStartCap:
+            self._startCapElementIds.append(capElementIds)
+        else:
+            self._endCapElementIds.append(capElementIds)
+
+    def _generateExtendedTubeElements(self, generateData, tubeBoxNodeIds, tubeRimNodeIds, coreBoundaryScalingMode,
+                                      isStartCap=True):
+        """
+        Blackbox function for generating extended tube elements.
+        :param generateData: TubeNetworkMeshGenerateData class object.
+        :param tubeBoxNodeIds: List of tube box nodes.
+        :param tubeRimNodeIds: List of tube rim nodes.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        """
+        idx = 0 if isStartCap else -1
+
+        coordinates = generateData.getCoordinates()
+        mesh = generateData.getMesh()
+        elementtemplateStd, eftStd = generateData.getStandardElementtemplate()
+        boxExtElementIds, rimExtElementIds = [], []
+
+        boxExtNodeIds = self._boxExtNodeIds[idx]
+        rimExtNodeIds = self._rimExtNodeIds[idx]
+
+        if self._isCore:
+            boxExtBoundaryNodeIds, boxExtBoundaryNodesToBoxIds = self._createBoundaryNodeIdsList(boxExtNodeIds)
+            tubeBoxBoundaryNodeIds, tubeBoxBoundaryNodesToBoxIds = self._createBoundaryNodeIdsList(tubeBoxNodeIds[idx])
+            # create box elements
+            for e3 in range(self._elementsCountCoreBoxMajor):
+                e3p = e3 + 1
+                for e1 in range(self._elementsCountCoreBoxMinor):
+                    nids = []
+                    for n1 in [e1, e1 + 1]:
+                        nids += [boxExtNodeIds[e3][n1], boxExtNodeIds[e3p][n1],
+                                 tubeBoxNodeIds[idx][e3][n1], tubeBoxNodeIds[idx][e3p][n1]]
+                        if not isStartCap:
+                            for a in [nids]:
+                                a[-4], a[-2] = a[-2], a[-4]
+                                a[-3], a[-1] = a[-1], a[-3]
+                    elementIdentifier = generateData.nextElementIdentifier()
+                    element = mesh.createElement(elementIdentifier, elementtemplateStd)
+                    element.setNodesByIdentifier(eftStd, nids)
+                    # for annotationMeshGroup in annotationMeshGroups:
+                    #     annotationMeshGroup.addElement(element)
+                boxExtElementIds.append(elementIdentifier)
+
+            # create core transition elements first layer after box
+            triplePointIndexesList = self._getTriplePointIndexes()
+            ringExtElementIds = []
+            for e1 in range(self._elementsCountAround):
+                nids, nodeParameters, nodeLayouts = [], [], []
+                n1p = (e1 + 1) % self._elementsCountAround
+                location = self._getTriplePointLocation(e1)
+                nodeLayoutTransition = generateData.getNodeLayoutTransition()
+                nodeLayoutTransitionTriplePoint = generateData.getNodeLayoutTransitionTriplePoint(location)
+                for n2 in [0, 1]:
+                    for n1 in [e1, n1p]:
+                        if n2 == 0:
+                            nid = boxExtBoundaryNodeIds[n1]
+                            mi, ni = boxExtBoundaryNodesToBoxIds[n1]
+                            nodeParameter = self._getBoxExtCoordinates(mi, ni, isStartCap)
+                            nodeLayout = nodeLayoutTransitionTriplePoint if n1 in triplePointIndexesList \
+                                else nodeLayoutTransition
+                        else:
+                            nid = tubeBoxBoundaryNodeIds[n1]
+                            mi, ni = tubeBoxBoundaryNodesToBoxIds[n1]
+                            nodeParameter = self._getTubeBoxCoordinates(mi, ni, isStartCap)
+                            nodeLayout = nodeLayoutTransitionTriplePoint if n1 in triplePointIndexesList \
+                                else nodeLayoutTransition
+                        nids += [nid]
+                        nodeParameters.append(nodeParameter)
+                        nodeLayouts.append(nodeLayout)
+                if not isStartCap:
+                    for a in [nids, nodeParameters, nodeLayouts]:
+                        a[-4], a[-2] = a[-2], a[-4]
+                        a[-3], a[-1] = a[-1], a[-3]
+                for n2 in [0, 1]:
+                    for n1 in [e1, n1p]:
+                        if n2 == 0:
+                            nid = rimExtNodeIds[0][n1]
+                            nodeParameter = self._getRimExtCoordinates(n1, 0, isStartCap)
+                            nodeLayout = None
+                        else:
+                            nid = tubeRimNodeIds[idx][0][n1]
+                            nodeParameter = self._getTubeRimCoordinates(n1, idx, 0)
+                            nodeLayout = None
+                        nids += [nid]
+                        nodeParameters.append(nodeParameter)
+                        nodeLayouts.append(nodeLayout)
+                if not isStartCap:
+                    for a in [nids, nodeParameters, nodeLayouts]:
+                        a[-4], a[-2] = a[-2], a[-4]
+                        a[-3], a[-1] = a[-1], a[-3]
+                eft, scalefactors = determineCubicHermiteSerendipityEft(mesh, nodeParameters, nodeLayouts)
+                if self._elementsCountTransition == 1:
+                    eft, scalefactors = generateData.resolveEftCoreBoundaryScaling(
+                        eft, scalefactors, nodeParameters, nids, coreBoundaryScalingMode)
+                elementtemplate = mesh.createElementtemplate()
+                elementtemplate.setElementShapeType(Element.SHAPE_TYPE_CUBE)
+                elementtemplate.defineField(coordinates, -1, eft)
+                elementIdentifier = generateData.nextElementIdentifier()
+                element = mesh.createElement(elementIdentifier, elementtemplate)
+                element.setNodesByIdentifier(eft, nids)
+                if scalefactors:
+                    element.setScaleFactors(eft, scalefactors)
+                # for annotationMeshGroup in annotationMeshGroups:
+                #     annotationMeshGroup.addElement(element)
+                ringExtElementIds.append(elementIdentifier)
+
+        # create regular rim elements - all elements outside first transition layer
+        elementsCountRim = self._getElementsCountRim()
+        elementsCountRimRegular = elementsCountRim - 1 if self._isCore else elementsCountRim
+        for e3 in range(elementsCountRimRegular):
+            ringExtElementIds = []
+            lastTransition = self._isCore and (e3 == (self._elementsCountTransition - 2))
+            for e1 in range(self._elementsCountAround):
+                elementtemplate, eft = elementtemplateStd, eftStd
+                n1p = (e1 + 1) % self._elementsCountAround
+                nids = []
+                for n3 in [e3, e3 + 1]:
+                    nids += [rimExtNodeIds[n3][e1], rimExtNodeIds[n3][n1p],
+                             tubeRimNodeIds[idx][n3][e1], tubeRimNodeIds[idx][n3][n1p]]
+                    if not isStartCap:
+                        for a in [nids]:
+                            a[-4], a[-2] = a[-2], a[-4]
+                            a[-3], a[-1] = a[-1], a[-3]
+                elementIdentifier = generateData.nextElementIdentifier()
+                scalefactors = []
+                if lastTransition:
+                    # get node parameters for computing scale factors
+                    nodeParameters = []
+                    for n3 in (e3, e3 + 1):
+                        for n2 in (0, 1):
+                            for n1 in (e1, n1p):
+                                if n2 == 0:
+                                    nodeParameter = self._getRimExtCoordinates(n1, n3, isStartCap)
+                                else:
+                                    nodeParameter = self._getTubeRimCoordinates(n1, idx, n3)
+                                nodeParameters.append(nodeParameter)
+                        if not isStartCap:
+                            for a in [nodeParameters]:
+                                a[-4], a[-2] = a[-2], a[-4]
+                                a[-3], a[-1] = a[-1], a[-3]
+                    eft = generateData.createElementfieldtemplate()
+                    eft, scalefactors = addTricubicHermiteSerendipityEftParameterScaling(
+                        eft, scalefactors, nodeParameters, [5, 6, 7, 8], Node.VALUE_LABEL_D_DS3)
+                    elementtemplateTransition = mesh.createElementtemplate()
+                    elementtemplateTransition.setElementShapeType(Element.SHAPE_TYPE_CUBE)
+                    elementtemplateTransition.defineField(coordinates, -1, eft)
+                    elementtemplate = elementtemplateTransition
+                element = mesh.createElement(elementIdentifier, elementtemplate)
+                element.setNodesByIdentifier(eft, nids)
+                if scalefactors:
+                    element.setScaleFactors(eft, scalefactors)
+                # for annotationMeshGroup in annotationMeshGroups:
+                #     annotationMeshGroup.addElement(element)
+                ringExtElementIds.append(elementIdentifier)
+        #     self._rimElementIds[e2].append(ringExtElementIds)
+
+    def sampleCoordinates(self):
+        """
+        Sample cap coordinates.
+        """
+        if self._isCore:
+            self._createShellCoordinatesList()
+            if self._isCap[0]:
+                self._determineCapCoordinatesWithCore(isStartCap=True)
+            if self._isCap[1]:
+                self._determineCapCoordinatesWithCore(isStartCap=False)
+        else:
+            if self._isCap[0]:
+                self._extendTubeEnds(isStartCap=True)
+                self._determineCapCoordinatesWithoutCore(isStartCap=True)
+            if self._isCap[1]:
+                self._extendTubeEnds(isStartCap=False)
+                self._determineCapCoordinatesWithoutCore(isStartCap=False)
+
+    def generateNodes(self, generateData, isStartCap=True, isCore=False):
+        """
+        Blackbox function for generating cap and extended tube nodes.
+        :param generateData: Class object from TubeNetworkMeshGenerateData.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :param isCore: True for generating a solid core inside the tube, False for regular tube network.
+        """
+        if isCore:
+            if isStartCap:
+                self._generateNodesWithCore(generateData, isStartCap)
+                self._generateExtendedTubeNodes(generateData, isStartCap)
+            else:
+                self._generateExtendedTubeNodes(generateData, isStartCap)
+                self._generateNodesWithCore(generateData, isStartCap)
+        else:
+            if isStartCap:
+                self._generateNodesWithoutCore(generateData, isStartCap)
+                self._generateExtendedTubeNodes(generateData, isStartCap)
+            else:
+                self._generateExtendedTubeNodes(generateData, isStartCap)
+                self._generateNodesWithoutCore(generateData, isStartCap)
+
+    def generateElements(self, generateData, elementsCountRim, tubeBoxNodeIds, tubeRimNodeIds, annotationMeshGroups,
+                         coreBoundaryScalingMode, isStartCap=True, isCore=False):
+        """
+        Blackbox function for generating cap and extended tube elements.
+        :param generateData: TubeNetworkMeshGenerateData class object.
+        :param elementsCountRim: Number of elements through the rim.
+        :param tubeBoxNodeIds: List of tube box nodes.
+        :param tubeRimNodeIds: List of tube rim nodes.
+        :param annotationMeshGroups: List of all annotated mesh groups.
+        :param coreBoundaryScalingMode: Mode 1 to set scale factors, 2 to add version 2 to d3 for the boundary nodes
+        and assigning values to that version equal to the scale factors x version 1.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
+        :param isCore: True for generating a solid core inside the tube, False for regular tube network.
+        """
+        if isCore:
+            self._generateElementsWithCore(generateData, coreBoundaryScalingMode, isStartCap)
+            self._generateExtendedTubeElements(generateData, tubeBoxNodeIds, tubeRimNodeIds, coreBoundaryScalingMode,
+                                               isStartCap)
+        else:
+            self._generateElementsWithoutCore(
+                generateData, elementsCountRim, tubeRimNodeIds, annotationMeshGroups, isStartCap)
+            self._generateExtendedTubeElements(generateData, tubeBoxNodeIds, tubeRimNodeIds, coreBoundaryScalingMode,
+                                               isStartCap)

--- a/src/scaffoldmaker/utils/eft_utils.py
+++ b/src/scaffoldmaker/utils/eft_utils.py
@@ -1121,7 +1121,8 @@ def addTricubicHermiteSerendipityEftParameterScaling(eft, scalefactors, nodePara
     :param localNodeIndexes: Local node indexes to scale value label at. Currently must be in [5, 6, 7, 8].
     :param valueLabel: Single value label to scale. Currently only implemened for D_DS3.
     :param version: Set to a number > 1 to use that derivative version instead of scale factors, and client is
-    responsible for assigning that derivative version in proportion to the returned scale factors.
+    responsible for assigning that derivative version in proportion to the returned scale factors. Versions 3 and 4
+    are used when the cap mesh is active, each representing the version used for start cap and end cap, respectively.
     :return: Modified eft, final scalefactors, add scalefactors (multiplying the affected derivatives; these are
     included in final scalefactors if version == 1, otherwise client must use these to scale versioned derivatives).
     """
@@ -1140,6 +1141,12 @@ def addTricubicHermiteSerendipityEftParameterScaling(eft, scalefactors, nodePara
         scalefactor = magnitude(dbScaled) / magnitude(db)
         addScalefactors.append(scalefactor)
     if version == 1:
+        newScalefactors = scalefactors + addScalefactors if scalefactors else addScalefactors
+        addScaleEftNodesValueLabel(eft, localNodeIndexes, Node.VALUE_LABEL_D_DS3, 3)
+        return eft, newScalefactors, addScalefactors
+    elif version in [3, 4]:
+        addScalefactors = addScalefactors[-2:] if version == 3 else addScalefactors[:2]
+        localNodeIndexes = [7, 8] if version == 3 else [5, 6]
         newScalefactors = scalefactors + addScalefactors if scalefactors else addScalefactors
         addScaleEftNodesValueLabel(eft, localNodeIndexes, Node.VALUE_LABEL_D_DS3, 3)
         return eft, newScalefactors, addScalefactors

--- a/src/scaffoldmaker/utils/eft_utils.py
+++ b/src/scaffoldmaker/utils/eft_utils.py
@@ -688,6 +688,29 @@ class HermiteNodeLayoutManager:
             [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, -1.0]])
         self.nodeLayoutsBifurcation6WayTriplePoint = {}
 
+        self._nodeLayoutCapShellTriplePointTopLeft = HermiteNodeLayout(
+            [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [0.0, -1.0, 0.0], [-1.0, 1.0, 0.0]])
+        self._nodeLayoutCapShellTriplePointTopRight = HermiteNodeLayout(
+            [[-1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [0.0, -1.0, 0.0], [1.0, 1.0, 0.0]])
+        self._nodeLayoutCapShellTriplePointBottomLeft = HermiteNodeLayout(
+            [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0], [-1.0, -1.0, 0.0]])
+        self._nodeLayoutCapShellTriplePointBottomRight = HermiteNodeLayout(
+            [[-1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0], [1.0, -1.0, 0.0]])
+
+        self._nodeLayoutCapBoxShield = None
+
+        self._nodeLayoutCapBoxShieldTriplePointTopLeft = HermiteNodeLayout(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [-1.0, 0.0, 1.0]])
+        self._nodeLayoutCapBoxShieldTriplePointTopRight = HermiteNodeLayout(
+            [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 0.0, 1.0]])
+
+        self._nodeLayoutCapBoxShieldTriplePointBottomLeft = HermiteNodeLayout(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [-1.0, 0.0, -1.0]])
+
+        self._nodeLayoutCapBoxShieldTriplePointBottomRight = HermiteNodeLayout(
+            [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, -1.0]])
+
+
     def getNodeLayoutRegularPermuted(self, d3Defined, limitDirections=None):
         """
         Get node layout for permutations of +/- d1, d2, d3, optionally limiting some directions.
@@ -813,7 +836,7 @@ class HermiteNodeLayoutManager:
                      [0.0, 0.0, 1.0], [0.0, 1.0, -1.0]])
                 nodeLayoutBifurcationCoreTransitionMMM = HermiteNodeLayout(
                     [[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [1.0, 1.0, 0.0],
-                     [0.0, 0.0, 11.0], [-1.0, -1.0, -1.0]])
+                     [0.0, 0.0, 1.0], [-1.0, -1.0, -1.0]])
                 nodeLayouts = (
                     nodeLayoutBifurcationCoreTransitionPOP,
                     nodeLayoutBifurcationCoreTransitionOPP,
@@ -838,6 +861,72 @@ class HermiteNodeLayoutManager:
                 else:
                     return self._nodeLayoutBifurcationCoreTransitionBottomGeneral
         return nodeLayouts[layoutIndex]
+
+    def getNodeLayoutCapTransition(self):
+        """
+        Get node layout for transition elements between the core box elements and the shell elements in the cap mesh.
+        :return: HermiteNodeLayout.
+        """
+        return self._nodeLayoutRegularPermuted_d3Defined
+
+    def getNodeLayoutCapShellTriplePoint(self):
+        """
+        Get node layout for triple-point corners of shell elements in the cap mesh. There are four corners
+        (Top Left, Top Right, Bottom Left, and Bottom Right) each with its specific node layout.
+        :return: HermiteNodeLayout.
+        """
+        nodeLayouts = [self._nodeLayoutCapShellTriplePointTopLeft, self._nodeLayoutCapShellTriplePointTopRight,
+                       self._nodeLayoutCapShellTriplePointBottomLeft, self._nodeLayoutCapShellTriplePointBottomRight]
+        return nodeLayouts
+
+    def getNodeLayoutCapBoxShield(self, isStartCap=True):
+        """
+        Get node layout for elements between the core box and the shield in the cap mesh. There are four types
+        (Top, Bottom, Left, and Right) each with its specific node layout. The node layout also changes direction in
+        the y-axis depending on whether the cap is at the start or the end of a tube segment.
+        :return: HermiteNodeLayout.
+        """
+        if isStartCap:
+            nodeLayoutCapBoxShieldTop = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0], [0.0, -1.0, 1.0]])
+            nodeLayoutCapBoxShieldBottom = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, -1.0, -1.0]])
+            nodeLayoutCapBoxShieldLeft = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [-1.0, -1.0, 0.0]])
+            nodeLayoutCapBoxShieldRight = HermiteNodeLayout(
+                [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [1.0, -1.0, 0.0]])
+        else:
+            nodeLayoutCapBoxShieldTop = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, -1.0, 0.0], [0.0, 1.0, 1.0]])
+            nodeLayoutCapBoxShieldBottom = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, -1.0]])
+            nodeLayoutCapBoxShieldLeft = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [-1.0, 1.0, 0.0]])
+            nodeLayoutCapBoxShieldRight = HermiteNodeLayout(
+                [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [1.0, 1.0, 0.0]])
+
+        self._nodeLayoutCapBoxShield = [nodeLayoutCapBoxShieldTop, nodeLayoutCapBoxShieldBottom,
+                                        nodeLayoutCapBoxShieldLeft, nodeLayoutCapBoxShieldRight]
+
+        return self._nodeLayoutCapBoxShield
+
+    def getNodeLayoutCapBoxShieldTriplePoint(self):
+        """
+        Get node layout for triple-point corners of core box elements in the cap mesh. There are four corners
+        (Top Left, Top Right, Bottom Left, and Bottom Right) each with its specific node layout.
+        :return: HermiteNodeLayout.
+        """
+        nodeLayouts = [self._nodeLayoutCapBoxShieldTriplePointTopLeft, self._nodeLayoutCapBoxShieldTriplePointTopRight,
+                       self._nodeLayoutCapBoxShieldTriplePointBottomLeft, self._nodeLayoutCapBoxShieldTriplePointBottomRight]
+
+        # limitDirections = [None, None, None]
+        # nodeLayouts[0] = HermiteNodeLayout(None, nodeLayouts[0], limitDirections)
+        # nodeLayout = nodeLayouts[0]
+        # permutations = nodeLayout.getPermutations()
+        # print("permutations", permutations)
+
+        return nodeLayouts
+
 
 def determineCubicHermiteSerendipityEft(mesh, nodeParameters, nodeLayouts):
     """

--- a/src/scaffoldmaker/utils/eft_utils.py
+++ b/src/scaffoldmaker/utils/eft_utils.py
@@ -22,12 +22,13 @@ def getEftTermScaling(eft, functionIndex, termIndex):
     scaleFactorCount, scaleFactorIndexes = eft.getTermScaling(functionIndex, termIndex, 1)
     if scaleFactorCount < 0:
         if eft.getNumberOfLocalScaleFactors() > 0:
-            print('getEftTermScaling function', functionIndex, ' term', termIndex, ' scaleFactorCount ', scaleFactorCount)
+            print('getEftTermScaling function', functionIndex, ' term', termIndex, ' scaleFactorCount ',
+                  scaleFactorCount)
         return []
     if scaleFactorCount == 0:
         return []
     if scaleFactorCount == 1:
-        return [ scaleFactorIndexes ]
+        return [scaleFactorIndexes]
     scaleFactorCount, scaleFactorIndexes = eft.getTermScaling(functionIndex, termIndex, scaleFactorCount)
     return scaleFactorIndexes
 
@@ -41,7 +42,8 @@ def mapEftFunction1Node1Term(eft, function, localNode, valueLabel, version, scal
     eft.setTermScaling(function, 1, scaleFactors)
 
 
-def mapEftFunction1Node2Terms(eft, function, localNode, valueLabel1, version1, scaleFactors1, valueLabel2, version2, scaleFactors2):
+def mapEftFunction1Node2Terms(eft, function, localNode, valueLabel1, version1, scaleFactors1, valueLabel2, version2,
+                              scaleFactors2):
     '''
     Set function of eft to sum 2 terms the respective valueLabels, versions from localNode with scaleFactors
     '''
@@ -62,7 +64,8 @@ def remapEftLocalNodes(eft, newNodeCount, localNodeIndexes):
     for f in range(1, functionCount + 1):
         termCount = eft.getFunctionNumberOfTerms(f)
         for t in range(1, termCount + 1):
-            eft.setTermNodeParameter(f, t, localNodeIndexes[eft.getTermLocalNodeIndex(f, t) - 1], eft.getTermNodeValueLabel(f, t), eft.getTermNodeVersion(f, t))
+            eft.setTermNodeParameter(f, t, localNodeIndexes[eft.getTermLocalNodeIndex(f, t) - 1],
+                                     eft.getTermNodeValueLabel(f, t), eft.getTermNodeVersion(f, t))
     eft.setNumberOfLocalNodes(newNodeCount)
 
 
@@ -130,7 +133,7 @@ def remapEftNodeValueLabelsVersion(eft, localNodeIndexes, valueLabels, version):
             valueLabel = eft.getTermNodeValueLabel(f, t)
             if (localNodeIndex in localNodeIndexes) and (valueLabel in valueLabels):
                 result = eft.setTermNodeParameter(f, t, localNodeIndex, valueLabel, version)
-                #print('remap result', result)
+                # print('remap result', result)
 
 
 def remapEftNodeValueLabelWithNodes(eft, localNodeIndex, fromValueLabel, expressionTerms):
@@ -145,7 +148,8 @@ def remapEftNodeValueLabelWithNodes(eft, localNodeIndex, fromValueLabel, express
     functionCount = eft.getNumberOfFunctions()
     for f in range(1, functionCount + 1):
         if eft.getFunctionNumberOfTerms(f) == 1:
-            if (eft.getTermLocalNodeIndex(f, 1) == localNodeIndex) and (eft.getTermNodeValueLabel(f, 1) == fromValueLabel) and (not getEftTermScaling(eft, f, 1)):
+            if (eft.getTermLocalNodeIndex(f, 1) == localNodeIndex) and (
+                    eft.getTermNodeValueLabel(f, 1) == fromValueLabel) and (not getEftTermScaling(eft, f, 1)):
                 termCount = len(expressionTerms)
                 eft.setFunctionNumberOfTerms(f, termCount)
                 version = eft.getTermNodeVersion(f, 1)
@@ -242,7 +246,7 @@ def createEftElementSurfaceLayer(elementIn, eftIn, eftfactory, eftStd, removeNod
     eft = eftStd
     scalefactors = None
     scaleFactorCountIn = eftIn.getNumberOfLocalScaleFactors()
-    scaleFactorsUsed = [False]*scaleFactorCountIn  # flag scale factors used on top surface of element
+    scaleFactorsUsed = [False] * scaleFactorCountIn  # flag scale factors used on top surface of element
     functionCountIn = eftIn.getNumberOfFunctions()
     halfFunctionCountIn = functionCountIn // 2
     elementBasis = eftfactory.getElementbasis()
@@ -268,7 +272,7 @@ def createEftElementSurfaceLayer(elementIn, eftIn, eftfactory, eftStd, removeNod
             scalingCount, scalingIndexes = eftIn.getTermScaling(fIn, t, 0)
             if scalingCount > 0:
                 scalingIndexes = eftIn.getTermScaling(fIn, t, scalingCount)[1]
-                #if (scalingCount > 1) or (scalingIndexes != 1):
+                # if (scalingCount > 1) or (scalingIndexes != 1):
                 #    print("Scaling", scalingIndexes)
                 if scalingCount == 1:
                     scalingIndexes = [scalingIndexes]
@@ -302,7 +306,7 @@ def createEftElementSurfaceLayer(elementIn, eftIn, eftfactory, eftStd, removeNod
             else:
                 newt = t
         assert noRemap or (newt > 0), "Element " + str(elementIn.getIdentifier()) + " f " + str(f) + \
-            " terms " + str(termCountIn)
+                                      " terms " + str(termCountIn)
     if True in scaleFactorsUsed:
         # get used scale factors, reorder indexes
         result, scalefactorsIn = elementIn.getScaleFactors(eftIn, scaleFactorCountIn)
@@ -474,9 +478,9 @@ def determineTricubicHermiteEft(mesh, nodeParameters, nodeDerivativeFixedWeights
                 functionNumber = n * 8 + crossDerivativeLabels[cd]
                 derivativeIndexes = \
                     [0, 1] if (cd == 0) else \
-                    [0, 2] if (cd == 1) else \
-                    [1, 2] if (cd == 2) else \
-                    [0, 1, 2]
+                        [0, 2] if (cd == 1) else \
+                            [1, 2] if (cd == 2) else \
+                                [0, 1, 2]
                 sign = 1.0
                 crossDerivativeLabel = Node.VALUE_LABEL_VALUE
                 for ed in derivativeIndexes:
@@ -537,6 +541,9 @@ class HermiteNodeLayout:
                 # permutations.append((directions[j], directions[i]))
         else:
             normDir = [normalize(dir) for dir in self._directions]
+            # print("directions", self._directions)
+            # print("normDir", normDir)
+            # print("directionsCount", directionsCount)
             for i in range(directionsCount - 2):
                 for j in range(i + 1, directionsCount - 1):
                     if dot(normDir[i], normDir[j]) < -0.9:
@@ -566,6 +573,7 @@ class HermiteNodeLayout:
                             permutations.append((self._directions[ii], self._directions[jj], self._directions[kk]))
                             permutations.append((self._directions[jj], self._directions[kk], self._directions[ii]))
                             permutations.append((self._directions[kk], self._directions[ii], self._directions[jj]))
+        # print("permutations", permutations)
         return permutations
 
     def getComplexity(self):
@@ -606,11 +614,13 @@ class HermiteNodeLayout:
         inwardNodeDeltas = [[-d for d in nodeDeltas[i]] if flips[i] else nodeDeltas[i] for i in swizzleIndexes]
         derivativeWeightsList = None
         greatestSimilarity = -1.0
+        # print("permutations", self._permutations)
         for permutation in self._permutations:
             # skip permutations using directions not in any supplied limitDirections
             skipPermutation = False
             limitIndex = 0
             for limitDirections in self._limitDirections:
+                # print("limitDirections", limitDirections)
                 if limitDirections:
                     weights = permutation[swizzleIndexes[limitIndex]]
                     if flips[limitIndex]:
@@ -641,9 +651,12 @@ class HermiteNodeLayout:
                     cosineSimilarity = dot(derivative, delta) / (magDerivative * magDelta)
                     # magnitudeSimilarity = math.exp(-math.fabs((magDerivative - magDelta) / magDelta))
                     similarity += cosineSimilarity  # * magnitudeSimilarity
+                    # print("similarity", similarity)
             if similarity > greatestSimilarity:
                 greatestSimilarity = similarity
                 derivativeWeightsList = permutation
+        # print("swizzleIndexes", swizzleIndexes)
+        # print("derivativeWeightsList", derivativeWeightsList)
         finalWeightsList = [
             [-w for w in derivativeWeightsList[swizzleIndexes[i]]] if flips[i]
             else derivativeWeightsList[swizzleIndexes[i]] for i in range(derivativesPerNode)
@@ -687,7 +700,6 @@ class HermiteNodeLayoutManager:
         self._nodeLayoutTriplePointBottomRight = HermiteNodeLayout(
             [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, -1.0]])
         self.nodeLayoutsBifurcation6WayTriplePoint = {}
-
         self._nodeLayoutCapShellTriplePointTopLeft = HermiteNodeLayout(
             [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [0.0, -1.0, 0.0], [-1.0, 1.0, 0.0]])
         self._nodeLayoutCapShellTriplePointTopRight = HermiteNodeLayout(
@@ -696,20 +708,8 @@ class HermiteNodeLayoutManager:
             [[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0], [-1.0, -1.0, 0.0]])
         self._nodeLayoutCapShellTriplePointBottomRight = HermiteNodeLayout(
             [[-1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0], [1.0, -1.0, 0.0]])
-
         self._nodeLayoutCapBoxShield = None
-
-        self._nodeLayoutCapBoxShieldTriplePointTopLeft = HermiteNodeLayout(
-            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [-1.0, 0.0, 1.0]])
-        self._nodeLayoutCapBoxShieldTriplePointTopRight = HermiteNodeLayout(
-            [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 0.0, 1.0]])
-
-        self._nodeLayoutCapBoxShieldTriplePointBottomLeft = HermiteNodeLayout(
-            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [-1.0, 0.0, -1.0]])
-
-        self._nodeLayoutCapBoxShieldTriplePointBottomRight = HermiteNodeLayout(
-            [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, -1.0]])
-
+        self._nodeLayoutCapBoxShieldTriplePoint = None
 
     def getNodeLayoutRegularPermuted(self, d3Defined, limitDirections=None):
         """
@@ -884,6 +884,8 @@ class HermiteNodeLayoutManager:
         Get node layout for elements between the core box and the shield in the cap mesh. There are four types
         (Top, Bottom, Left, and Right) each with its specific node layout. The node layout also changes direction in
         the y-axis depending on whether the cap is at the start or the end of a tube segment.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
         :return: HermiteNodeLayout.
         """
         if isStartCap:
@@ -910,22 +912,38 @@ class HermiteNodeLayoutManager:
 
         return self._nodeLayoutCapBoxShield
 
-    def getNodeLayoutCapBoxShieldTriplePoint(self):
+    def getNodeLayoutCapBoxShieldTriplePoint(self, isStartCap=True):
         """
         Get node layout for triple-point corners of core box elements in the cap mesh. There are four corners
         (Top Left, Top Right, Bottom Left, and Bottom Right) each with its specific node layout.
+        :param isStartCap: True if generating a cap mesh at the start of a tube segment, False if generating at the end
+        of a tube segment.
         :return: HermiteNodeLayout.
         """
-        nodeLayouts = [self._nodeLayoutCapBoxShieldTriplePointTopLeft, self._nodeLayoutCapBoxShieldTriplePointTopRight,
-                       self._nodeLayoutCapBoxShieldTriplePointBottomLeft, self._nodeLayoutCapBoxShieldTriplePointBottomRight]
+        if isStartCap:
+            nodeLayoutCapBoxShieldTriplePointTopLeft = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0], [-1.0, -1.0, 1.0]])
+            nodeLayoutCapBoxShieldTriplePointTopRight = HermiteNodeLayout(
+                [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0], [1.0, -1.0, 1.0]])
+            nodeLayoutCapBoxShieldTriplePointBottomLeft = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [-1.0, -1.0, -1.0]])
+            nodeLayoutCapBoxShieldTriplePointBottomRight = HermiteNodeLayout(
+                [[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, -1.0, -1.0]])
+        else:
+            nodeLayoutCapBoxShieldTriplePointTopLeft = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [-1.0, 1.0, 1.0]])
+            nodeLayoutCapBoxShieldTriplePointTopRight = HermiteNodeLayout(
+                [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 1.0, 1.0]])
+            nodeLayoutCapBoxShieldTriplePointBottomLeft = HermiteNodeLayout(
+                [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [-1.0, 1.0, -1.0]])
+            nodeLayoutCapBoxShieldTriplePointBottomRight = HermiteNodeLayout(
+                [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 1.0, -1.0]])
 
-        # limitDirections = [None, None, None]
-        # nodeLayouts[0] = HermiteNodeLayout(None, nodeLayouts[0], limitDirections)
-        # nodeLayout = nodeLayouts[0]
-        # permutations = nodeLayout.getPermutations()
-        # print("permutations", permutations)
+        self._nodeLayoutCapBoxShieldTriplePoint = \
+            [nodeLayoutCapBoxShieldTriplePointTopLeft, nodeLayoutCapBoxShieldTriplePointTopRight,
+             nodeLayoutCapBoxShieldTriplePointBottomLeft, nodeLayoutCapBoxShieldTriplePointBottomRight]
 
-        return nodeLayouts
+        return self._nodeLayoutCapBoxShieldTriplePoint
 
 
 def determineCubicHermiteSerendipityEft(mesh, nodeParameters, nodeLayouts):
@@ -1009,7 +1027,7 @@ def determineCubicHermiteSerendipityEft(mesh, nodeParameters, nodeLayouts):
             nodeParameters[n][1],
             nodeParameters[n][2],
             nodeParameters[n][3] if d3Defined else None]
-        derivativeWeightsList =\
+        derivativeWeightsList = \
             nodeLayout.getDerivativeWeightsList(deltas[n], nodeDerivatives, n) if nodeLayout else None
         for ed in range(derivativesPerNode):
             if nodeLayout:

--- a/src/scaffoldmaker/utils/tubenetworkmesh.py
+++ b/src/scaffoldmaker/utils/tubenetworkmesh.py
@@ -1766,9 +1766,6 @@ class TubeNetworkMeshSegment(NetworkMeshSegment):
                     elementtemplate.setElementShapeType(Element.SHAPE_TYPE_CUBE)
                     elementtemplate.defineField(coordinates, -1, eft)
                     elementIdentifier = generateData.nextElementIdentifier()
-                    if elementIdentifier in [53, 54]:
-                        print("self._coreBoundaryScalingMode", self._coreBoundaryScalingMode)
-                        print("tube scalefactors", scalefactors)
                     element = mesh.createElement(elementIdentifier, elementtemplate)
                     element.setNodesByIdentifier(eft, nids)
                     if scalefactors:

--- a/src/scaffoldmaker/utils/tubenetworkmesh.py
+++ b/src/scaffoldmaker/utils/tubenetworkmesh.py
@@ -208,11 +208,11 @@ class TubeNetworkMeshGenerateData(NetworkMeshGenerateData):
         self._nodeLayoutCapBoxShield = nodeLayout
         return self._nodeLayoutCapBoxShield
 
-    def getNodeLayoutCapBoxShieldTriplePoint(self, location):
+    def getNodeLayoutCapBoxShieldTriplePoint(self, location, isStartCap=True):
         """
 
         """
-        nodeLayouts = self._nodeLayoutManager.getNodeLayoutCapBoxShieldTriplePoint()
+        nodeLayouts = self._nodeLayoutManager.getNodeLayoutCapBoxShieldTriplePoint(isStartCap)
         assert location in [1, -1, 2, -2, 0]
         if location == 1:  # "Top Left"
             nodeLayout = nodeLayouts[0]

--- a/tests/test_capmesh.py
+++ b/tests/test_capmesh.py
@@ -26,7 +26,7 @@ class CapScaffoldTestCase(unittest.TestCase):
         networkLayoutSettings = networkLayoutScaffoldPackage.getScaffoldSettings()
         # change the network layout to have cap at both ends of the tube
         networkLayoutSettings["Structure"] = "(1-2)"
-        self.assertEqual("(1-2)",networkLayoutSettings["Structure"])
+        self.assertEqual("(1-2)", networkLayoutSettings["Structure"])
 
         self.assertTrue(networkLayoutSettings["Define inner coordinates"])
         self.assertEqual(13, len(settings))
@@ -156,10 +156,8 @@ class CapScaffoldTestCase(unittest.TestCase):
             result, surfaceArea = surfaceAreaField.evaluateReal(fieldcache, 1)
             self.assertEqual(result, RESULT_OK)
 
-            self.assertAlmostEqual(volume, 0.03928467254863209, delta=X_TOL)
-            self.assertAlmostEqual(surfaceArea, 0.8736482362813334, delta=X_TOL)
-
-
+            self.assertAlmostEqual(volume, 0.03930782850767879, delta=X_TOL)
+            self.assertAlmostEqual(surfaceArea, 0.8285291049289928, delta=X_TOL)
 
     def test_3d_cap_tube_network_bifurcation(self):
         """
@@ -300,8 +298,8 @@ class CapScaffoldTestCase(unittest.TestCase):
             result, surfaceArea = surfaceAreaField.evaluateReal(fieldcache, 1)
             self.assertEqual(result, RESULT_OK)
 
-            self.assertAlmostEqual(volume, 0.11101973283867012, delta=X_TOL)
-            self.assertAlmostEqual(surfaceArea, 2.3035471266966363, delta=X_TOL)
+            self.assertAlmostEqual(volume, 0.11105681500696916, delta=X_TOL)
+            self.assertAlmostEqual(surfaceArea, 2.2359565854658427, delta=X_TOL)
 
     def test_3d_tube_network_converging_bifurcation_core(self):
         """
@@ -395,8 +393,8 @@ class CapScaffoldTestCase(unittest.TestCase):
             result, surfaceArea = surfaceAreaField.evaluateReal(fieldcache, 1)
             self.assertEqual(result, RESULT_OK)
 
-            self.assertAlmostEqual(volume, 0.11060465010614413, delta=X_TOL)
-            self.assertAlmostEqual(surfaceArea, 2.3003361436808776, delta=X_TOL)
+            self.assertAlmostEqual(volume, 0.1106252097801163, delta=X_TOL)
+            self.assertAlmostEqual(surfaceArea, 2.233433190529325, delta=X_TOL)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_capmesh.py
+++ b/tests/test_capmesh.py
@@ -1,0 +1,402 @@
+import unittest
+
+from cmlibs.utils.zinc.finiteelement import evaluateFieldNodesetRange
+from cmlibs.utils.zinc.general import ChangeManager
+from cmlibs.utils.zinc.group import identifier_ranges_to_string, mesh_group_add_identifier_ranges, \
+    mesh_group_to_identifier_ranges
+from cmlibs.zinc.context import Context
+from cmlibs.zinc.element import Element
+from cmlibs.zinc.field import Field
+from cmlibs.zinc.result import RESULT_OK
+from scaffoldmaker.annotation.annotationgroup import findAnnotationGroupByName
+from scaffoldmaker.meshtypes.meshtype_3d_tubenetwork1 import MeshType_3d_tubenetwork1
+from scaffoldmaker.scaffoldpackage import ScaffoldPackage
+
+from testutils import assertAlmostEqualList
+
+class CapScaffoldTestCase(unittest.TestCase):
+
+    def test_3d_cap_tube_network_default(self):
+        """
+        Test default 3-D tube network with cap at both ends is generated correctly.
+        """
+        scaffoldPackage = ScaffoldPackage(MeshType_3d_tubenetwork1, defaultParameterSetName="Default")
+        settings = scaffoldPackage.getScaffoldSettings()
+        networkLayoutScaffoldPackage = settings["Network layout"]
+        networkLayoutSettings = networkLayoutScaffoldPackage.getScaffoldSettings()
+        # change the network layout to have cap at both ends of the tube
+        networkLayoutSettings["Structure"] = "(1-2)"
+        self.assertEqual("(1-2)",networkLayoutSettings["Structure"])
+
+        self.assertTrue(networkLayoutSettings["Define inner coordinates"])
+        self.assertEqual(13, len(settings))
+        self.assertEqual(8, settings["Number of elements around"])
+        self.assertEqual(1, settings["Number of elements through shell"])
+        self.assertEqual([0], settings["Annotation numbers of elements around"])
+        self.assertEqual(4.0, settings["Target element density along longest segment"])
+        self.assertEqual([0], settings["Annotation numbers of elements along"])
+        self.assertFalse(settings["Use linear through shell"])
+        self.assertTrue(settings["Use outer trim surfaces"])
+        self.assertFalse(settings["Show trim surfaces"])
+        self.assertFalse(settings["Core"])
+        self.assertEqual(2, settings["Number of elements across core box minor"])
+        self.assertEqual(1, settings["Number of elements across core transition"])
+        self.assertEqual([0], settings["Annotation numbers of elements across core box minor"])
+
+        context = Context("Test")
+        region = context.getDefaultRegion()
+        self.assertTrue(region.isValid())
+        scaffoldPackage.generate(region)
+
+        fieldmodule = region.getFieldmodule()
+
+        mesh3d = fieldmodule.findMeshByDimension(3)
+        self.assertEqual(8 * 4 + 8 * 3 * 2, mesh3d.getSize())
+        nodes = fieldmodule.findNodesetByFieldDomainType(Field.DOMAIN_TYPE_NODES)
+        self.assertEqual((8 * 5 + 8 * 2 * 2 + 2) * 2, nodes.getSize())
+        coordinates = fieldmodule.findFieldByName("coordinates").castFiniteElement()
+        self.assertTrue(coordinates.isValid())
+
+        X_TOL = 1.0E-6
+
+        minimums, maximums = evaluateFieldNodesetRange(coordinates, nodes)
+        assertAlmostEqualList(self, minimums, [-0.150, -0.100, -0.100], X_TOL)
+        assertAlmostEqualList(self, maximums, [1.150, 0.100, 0.100], X_TOL)
+
+        with ChangeManager(fieldmodule):
+            one = fieldmodule.createFieldConstant(1.0)
+            isExterior = fieldmodule.createFieldIsExterior()
+            isExteriorXi3_0 = fieldmodule.createFieldAnd(
+                isExterior, fieldmodule.createFieldIsOnFace(Element.FACE_TYPE_XI3_0))
+            isExteriorXi3_1 = fieldmodule.createFieldAnd(
+                isExterior, fieldmodule.createFieldIsOnFace(Element.FACE_TYPE_XI3_1))
+            mesh2d = fieldmodule.findMeshByDimension(2)
+            fieldcache = fieldmodule.createFieldcache()
+
+            volumeField = fieldmodule.createFieldMeshIntegral(one, coordinates, mesh3d)
+            volumeField.setNumbersOfPoints(4)
+            result, volume = volumeField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            outerSurfaceAreaField = fieldmodule.createFieldMeshIntegral(isExteriorXi3_1, coordinates, mesh2d)
+            outerSurfaceAreaField.setNumbersOfPoints(4)
+            result, outerSurfaceArea = outerSurfaceAreaField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            innerSurfaceAreaField = fieldmodule.createFieldMeshIntegral(isExteriorXi3_0, coordinates, mesh2d)
+            innerSurfaceAreaField.setNumbersOfPoints(4)
+            result, innerSurfaceArea = innerSurfaceAreaField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            self.assertAlmostEqual(volume, 0.01475819159418598, delta=X_TOL)
+            self.assertAlmostEqual(outerSurfaceArea, 0.83785503770891, delta=X_TOL)
+            self.assertAlmostEqual(innerSurfaceArea, 0.6527066474646166, delta=X_TOL)
+
+    def test_3d_cap_tube_network_default_core(self):
+        """
+        Test default 3-D tube network with cap at both ends and with a solid core is generated correctly.
+        """
+        scaffoldPackage = ScaffoldPackage(MeshType_3d_tubenetwork1, defaultParameterSetName="Default")
+        settings = scaffoldPackage.getScaffoldSettings()
+        networkLayoutScaffoldPackage = settings["Network layout"]
+        networkLayoutSettings = networkLayoutScaffoldPackage.getScaffoldSettings()
+        # change the network layout to have cap at both ends of the tube
+        networkLayoutSettings["Structure"] = "(1-2)"
+        self.assertEqual("(1-2)",networkLayoutSettings["Structure"])
+
+        self.assertTrue(networkLayoutSettings["Define inner coordinates"])
+        self.assertEqual(13, len(settings))
+        self.assertEqual(8, settings["Number of elements around"])
+        self.assertEqual(1, settings["Number of elements through shell"])
+        self.assertEqual([0], settings["Annotation numbers of elements around"])
+        self.assertEqual(4.0, settings["Target element density along longest segment"])
+        self.assertEqual([0], settings["Annotation numbers of elements along"])
+        self.assertFalse(settings["Use linear through shell"])
+        self.assertTrue(settings["Use outer trim surfaces"])
+        self.assertFalse(settings["Show trim surfaces"])
+        self.assertFalse(settings["Core"])
+        self.assertEqual(2, settings["Number of elements across core box minor"])
+        self.assertEqual(1, settings["Number of elements across core transition"])
+        self.assertEqual([0], settings["Annotation numbers of elements across core box minor"])
+        settings["Core"] = True
+
+        context = Context("Test")
+        region = context.getDefaultRegion()
+        self.assertTrue(region.isValid())
+        scaffoldPackage.generate(region)
+
+        fieldmodule = region.getFieldmodule()
+
+        mesh3d = fieldmodule.findMeshByDimension(3)
+        self.assertEqual((8 + 8 + 4) * 4 + ((8 + 8 + 4) * 2 + 4 + 4) * 2, mesh3d.getSize())
+        nodes = fieldmodule.findNodesetByFieldDomainType(Field.DOMAIN_TYPE_NODES)
+        self.assertEqual((8 + 8 + 9) * 5 + ((8 + 8 + 9) + 9 * 3) * 2, nodes.getSize())
+        coordinates = fieldmodule.findFieldByName("coordinates").castFiniteElement()
+        self.assertTrue(coordinates.isValid())
+
+        X_TOL = 1.0E-6
+
+        minimums, maximums = evaluateFieldNodesetRange(coordinates, nodes)
+        assertAlmostEqualList(self, minimums, [-0.150, -0.100, -0.100], X_TOL)
+        assertAlmostEqualList(self, maximums, [1.150, 0.100, 0.100], X_TOL)
+
+        with ChangeManager(fieldmodule):
+            one = fieldmodule.createFieldConstant(1.0)
+            isExterior = fieldmodule.createFieldIsExterior()
+            mesh2d = fieldmodule.findMeshByDimension(2)
+            fieldcache = fieldmodule.createFieldcache()
+
+            volumeField = fieldmodule.createFieldMeshIntegral(one, coordinates, mesh3d)
+            volumeField.setNumbersOfPoints(4)
+            result, volume = volumeField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            surfaceAreaField = fieldmodule.createFieldMeshIntegral(isExterior, coordinates, mesh2d)
+            surfaceAreaField.setNumbersOfPoints(4)
+            result, surfaceArea = surfaceAreaField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            self.assertAlmostEqual(volume, 0.03928467254863209, delta=X_TOL)
+            self.assertAlmostEqual(surfaceArea, 0.8736482362813334, delta=X_TOL)
+
+
+
+    def test_3d_cap_tube_network_bifurcation(self):
+        """
+        Test bifurcation 3-D tube network with cap at both ends is generated correctly.
+        """
+        scaffoldPackage = ScaffoldPackage(MeshType_3d_tubenetwork1, defaultParameterSetName="Bifurcation")
+        settings = scaffoldPackage.getScaffoldSettings()
+        networkLayoutScaffoldPackage = settings["Network layout"]
+        networkLayoutSettings = networkLayoutScaffoldPackage.getScaffoldSettings()
+        # change the network layout to have cap at both ends of the tube
+        networkLayoutSettings["Structure"] = "(1-2.1,2.2-3),2.3-4)"
+        self.assertEqual("(1-2.1,2.2-3),2.3-4)",networkLayoutSettings["Structure"])
+
+        self.assertTrue(networkLayoutSettings["Define inner coordinates"])
+        self.assertEqual(13, len(settings))
+        self.assertEqual(8, settings["Number of elements around"])
+        self.assertEqual(1, settings["Number of elements through shell"])
+        self.assertEqual([0], settings["Annotation numbers of elements around"])
+        self.assertEqual(4.0, settings["Target element density along longest segment"])
+        self.assertEqual([0], settings["Annotation numbers of elements along"])
+        self.assertFalse(settings["Use linear through shell"])
+        self.assertTrue(settings["Use outer trim surfaces"])
+        self.assertFalse(settings["Show trim surfaces"])
+        self.assertFalse(settings["Core"])
+        self.assertEqual(2, settings["Number of elements across core box minor"])
+        self.assertEqual(1, settings["Number of elements across core transition"])
+        self.assertEqual([0], settings["Annotation numbers of elements across core box minor"])
+
+        context = Context("Test")
+        region = context.getDefaultRegion()
+        self.assertTrue(region.isValid())
+        scaffoldPackage.generate(region)
+
+        fieldmodule = region.getFieldmodule()
+
+        mesh3d = fieldmodule.findMeshByDimension(3)
+        self.assertEqual((8 * 4 + 8 * 3) * 3 , mesh3d.getSize())
+        nodes = fieldmodule.findNodesetByFieldDomainType(Field.DOMAIN_TYPE_NODES)
+        self.assertEqual((8 * 4 * 3 + 3 * 3 + 2) * 2 + (8 * 2 * 2 + 2) * 3, nodes.getSize())
+        coordinates = fieldmodule.findFieldByName("coordinates").castFiniteElement()
+        self.assertTrue(coordinates.isValid())
+
+        X_TOL = 1.0E-6
+
+        minimums, maximums = evaluateFieldNodesetRange(coordinates, nodes)
+        assertAlmostEqualList(self, minimums, [-0.1500000000000000, -0.6246941344953365, -0.1000000000000000], X_TOL)
+        assertAlmostEqualList(self, maximums, [2.1433222518126906, 0.6276801844614515, 0.1000000000000000], X_TOL)
+
+        with ChangeManager(fieldmodule):
+            one = fieldmodule.createFieldConstant(1.0)
+            isExterior = fieldmodule.createFieldIsExterior()
+            isExteriorXi3_0 = fieldmodule.createFieldAnd(
+                isExterior, fieldmodule.createFieldIsOnFace(Element.FACE_TYPE_XI3_0))
+            isExteriorXi3_1 = fieldmodule.createFieldAnd(
+                isExterior, fieldmodule.createFieldIsOnFace(Element.FACE_TYPE_XI3_1))
+            mesh2d = fieldmodule.findMeshByDimension(2)
+            fieldcache = fieldmodule.createFieldcache()
+
+            volumeField = fieldmodule.createFieldMeshIntegral(one, coordinates, mesh3d)
+            volumeField.setNumbersOfPoints(4)
+            result, volume = volumeField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            outerSurfaceAreaField = fieldmodule.createFieldMeshIntegral(isExteriorXi3_1, coordinates, mesh2d)
+            outerSurfaceAreaField.setNumbersOfPoints(4)
+            result, outerSurfaceArea = outerSurfaceAreaField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            innerSurfaceAreaField = fieldmodule.createFieldMeshIntegral(isExteriorXi3_0, coordinates, mesh2d)
+            innerSurfaceAreaField.setNumbersOfPoints(4)
+            result, innerSurfaceArea = innerSurfaceAreaField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            self.assertAlmostEqual(volume, 0.04024808736450315, delta=X_TOL)
+            self.assertAlmostEqual(outerSurfaceArea, 2.251027047006869, delta=X_TOL)
+            self.assertAlmostEqual(innerSurfaceArea, 1.7914675669958757, delta=X_TOL)
+
+    def test_3d_tube_network_bifurcation_core(self):
+        """
+        Test bifurcation 3-D tube network with solid core and cap at both ends is generated correctly.
+        """
+        scaffoldPackage = ScaffoldPackage(MeshType_3d_tubenetwork1, defaultParameterSetName="Bifurcation")
+        settings = scaffoldPackage.getScaffoldSettings()
+        networkLayoutScaffoldPackage = settings["Network layout"]
+        networkLayoutSettings = networkLayoutScaffoldPackage.getScaffoldSettings()
+        # change the network layout to have cap at both ends of the tube
+        networkLayoutSettings["Structure"] = "(1-2.1,2.2-3),2.3-4)"
+        self.assertEqual("(1-2.1,2.2-3),2.3-4)",networkLayoutSettings["Structure"])
+
+        self.assertTrue(networkLayoutSettings["Define inner coordinates"])
+        self.assertEqual(13, len(settings))
+        self.assertEqual(8, settings["Number of elements around"])
+        self.assertEqual(1, settings["Number of elements through shell"])
+        self.assertEqual([0], settings["Annotation numbers of elements around"])
+        self.assertEqual(4.0, settings["Target element density along longest segment"])
+        self.assertEqual([0], settings["Annotation numbers of elements along"])
+        self.assertFalse(settings["Use linear through shell"])
+        self.assertFalse(settings["Show trim surfaces"])
+        self.assertFalse(settings["Core"])
+        self.assertEqual(2, settings["Number of elements across core box minor"])
+        self.assertEqual(1, settings["Number of elements across core transition"])
+        self.assertEqual([0], settings["Annotation numbers of elements across core box minor"])
+        settings["Core"] = True
+
+        context = Context("Test")
+        region = context.getDefaultRegion()
+        self.assertTrue(region.isValid())
+        scaffoldPackage.generate(region)
+
+        fieldmodule = region.getFieldmodule()
+
+        mesh3d = fieldmodule.findMeshByDimension(3)
+        self.assertEqual((8 * 4 * 3) * 2 + (4 * 4 * 3) +((8 + 8 + 4) * 2 + 4 + 4) * 3, mesh3d.getSize())
+        nodes = fieldmodule.findNodesetByFieldDomainType(Field.DOMAIN_TYPE_NODES)
+        self.assertEqual((8 * 4 * 3 + 3 * 3 + 2) * 2 + (9 * 4 * 3 + 3 * 4) + ((8 + 8 + 9) + 9 * 3) * 3, nodes.getSize())
+        coordinates = fieldmodule.findFieldByName("coordinates").castFiniteElement()
+        self.assertTrue(coordinates.isValid())
+
+        X_TOL = 1.0E-6
+
+        minimums, maximums = evaluateFieldNodesetRange(coordinates, nodes)
+        assertAlmostEqualList(self, minimums, [-0.1500000000000000, -0.6172290095800493, -0.1000000000000000], X_TOL)
+        assertAlmostEqualList(self, maximums, [2.1395896893550477, 0.6172290095800493, 0.1000000000000000], X_TOL)
+
+        with ChangeManager(fieldmodule):
+            one = fieldmodule.createFieldConstant(1.0)
+            isExterior = fieldmodule.createFieldIsExterior()
+            mesh2d = fieldmodule.findMeshByDimension(2)
+            fieldcache = fieldmodule.createFieldcache()
+
+            volumeField = fieldmodule.createFieldMeshIntegral(one, coordinates, mesh3d)
+            volumeField.setNumbersOfPoints(4)
+            result, volume = volumeField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            surfaceAreaField = fieldmodule.createFieldMeshIntegral(isExterior, coordinates, mesh2d)
+            surfaceAreaField.setNumbersOfPoints(4)
+            result, surfaceArea = surfaceAreaField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            self.assertAlmostEqual(volume, 0.11101973283867012, delta=X_TOL)
+            self.assertAlmostEqual(surfaceArea, 2.3035471266966363, delta=X_TOL)
+
+    def test_3d_tube_network_converging_bifurcation_core(self):
+        """
+        Test converging bifurcation 3-D tube network with solid core and 12, 12, 8 elements around.
+        """
+        scaffoldPackage = ScaffoldPackage(MeshType_3d_tubenetwork1, defaultParameterSetName="Bifurcation")
+        settings = scaffoldPackage.getScaffoldSettings()
+        networkLayoutScaffoldPackage = settings["Network layout"]
+        networkLayoutSettings = networkLayoutScaffoldPackage.getScaffoldSettings()
+        # change the network layout to have cap at both ends of the tube
+        networkLayoutSettings["Structure"] = "(1-3.1,(2-3.2,3.3-4)"
+        self.assertEqual("(1-3.1,(2-3.2,3.3-4)",networkLayoutSettings["Structure"])
+
+        self.assertTrue(networkLayoutSettings["Define inner coordinates"])
+        self.assertEqual(13, len(settings))
+        self.assertEqual(8, settings["Number of elements around"])
+        self.assertEqual(1, settings["Number of elements through shell"])
+        self.assertEqual([0], settings["Annotation numbers of elements around"])
+        self.assertEqual(4.0, settings["Target element density along longest segment"])
+        self.assertEqual([0], settings["Annotation numbers of elements along"])
+        self.assertFalse(settings["Use linear through shell"])
+        self.assertFalse(settings["Show trim surfaces"])
+        self.assertFalse(settings["Core"])
+        self.assertEqual(2, settings["Number of elements across core box minor"])
+        self.assertEqual(1, settings["Number of elements across core transition"])
+        self.assertEqual([0], settings["Annotation numbers of elements across core box minor"])
+        settings["Core"] = True
+        settings["Number of elements around"] = 12
+        settings["Annotation numbers of elements around"] = [8]
+
+        context = Context("Test")
+        region = context.getDefaultRegion()
+
+        # add a user-defined annotation group to network layout to vary elements count around. Must generate first
+        tmpRegion = region.createRegion()
+        tmpFieldmodule = tmpRegion.getFieldmodule()
+        networkLayoutScaffoldPackage.generate(tmpRegion)
+
+        annotationGroup1 = networkLayoutScaffoldPackage.createUserAnnotationGroup(("segment 3", "SEGMENT:3"))
+        group = annotationGroup1.getGroup()
+        mesh1d = tmpFieldmodule.findMeshByDimension(1)
+        meshGroup = group.createMeshGroup(mesh1d)
+        mesh_group_add_identifier_ranges(meshGroup, [[3, 3]])
+        self.assertEqual(1, meshGroup.getSize())
+        self.assertEqual(1, annotationGroup1.getDimension())
+        identifier_ranges_string = identifier_ranges_to_string(mesh_group_to_identifier_ranges(meshGroup))
+        self.assertEqual("3", identifier_ranges_string)
+        networkLayoutScaffoldPackage.updateUserAnnotationGroups()
+
+        self.assertTrue(region.isValid())
+        scaffoldPackage.generate(region)
+        annotationGroups = scaffoldPackage.getAnnotationGroups()
+        self.assertEqual(3, len(annotationGroups))
+        self.assertTrue(findAnnotationGroupByName(annotationGroups, "core") is not None)
+        self.assertTrue(findAnnotationGroupByName(annotationGroups, "shell") is not None)
+
+        fieldmodule = region.getFieldmodule()
+
+        mesh3d = fieldmodule.findMeshByDimension(3)
+        self.assertEqual(544, mesh3d.getSize())
+        nodes = fieldmodule.findNodesetByFieldDomainType(Field.DOMAIN_TYPE_NODES)
+        self.assertEqual(680, nodes.getSize())
+        coordinates = fieldmodule.findFieldByName("coordinates").castFiniteElement()
+        self.assertTrue(coordinates.isValid())
+
+        # check annotation group transferred to 3D tube
+        annotationGroup = findAnnotationGroupByName(annotationGroups, "segment 3")
+        self.assertTrue(annotationGroup is not None)
+        self.assertEqual("SEGMENT:3", annotationGroup.getId())
+        self.assertEqual(80, annotationGroup.getMeshGroup(fieldmodule.findMeshByDimension(3)).getSize())
+
+        X_TOL = 1.0E-6
+
+        minimums, maximums = evaluateFieldNodesetRange(coordinates, nodes)
+        assertAlmostEqualList(self, minimums, [-0.14453769545049167, -0.6221797157655231, -0.1000000000000000], X_TOL)
+        assertAlmostEqualList(self, maximums, [2.15, 0.6221795584199485, 0.1000000000000000], X_TOL)
+
+        with ChangeManager(fieldmodule):
+            one = fieldmodule.createFieldConstant(1.0)
+            isExterior = fieldmodule.createFieldIsExterior()
+            mesh2d = fieldmodule.findMeshByDimension(2)
+            fieldcache = fieldmodule.createFieldcache()
+
+            volumeField = fieldmodule.createFieldMeshIntegral(one, coordinates, mesh3d)
+            volumeField.setNumbersOfPoints(4)
+            result, volume = volumeField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            surfaceAreaField = fieldmodule.createFieldMeshIntegral(isExterior, coordinates, mesh2d)
+            surfaceAreaField.setNumbersOfPoints(4)
+            result, surfaceArea = surfaceAreaField.evaluateReal(fieldcache, 1)
+            self.assertEqual(result, RESULT_OK)
+
+            self.assertAlmostEqual(volume, 0.11060465010614413, delta=X_TOL)
+            self.assertAlmostEqual(surfaceArea, 2.3003361436808776, delta=X_TOL)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add cap mesh that generates cap(s) at either ends of a tube network.
Works by adding "(" and ")" at the ends of a network layout structure, e.g. (1-2) creates a default tube network with caps at both ends.